### PR TITLE
move overload log inside conditional block in /sql-chat error handler

### DIFF
--- a/apps/api/src/routers/ai.ts
+++ b/apps/api/src/routers/ai.ts
@@ -113,9 +113,9 @@ ai.post('/sql-chat', arktypeValidator('json', input), async (c) => {
   catch (error) {
     const isOverloaded = error instanceof Error && error.message.includes('Overloaded')
 
-    console.log('Request overloaded, trying to use fallback model')
-
     if (isOverloaded) {
+      console.log('Request overloaded, trying to use fallback model')
+
       const result = generateStream({
         type,
         model: !model || model === 'auto' ? anthropic('claude-3-5-haiku-latest') : models[model],
@@ -127,6 +127,8 @@ ai.post('/sql-chat', arktypeValidator('json', input), async (c) => {
 
       return result.toDataStreamResponse()
     }
+
+    console.log('Unhandled error in /sql-chat route:', error)
 
     throw error
   }


### PR DESCRIPTION
### Summary

This PR makes a small logging adjustment in the `/sql-chat` route:

- Moved the `console.log('Request overloaded, trying to use fallback model')` statement **inside** the `if (isOverloaded)` block.

### Why

Previously, the overload message was being logged for **all errors**, even when the error wasn't related to overload. This was misleading in the logs. Now, the message is only logged when the error actually includes `'Overloaded'`.

### Changes

- Relocated the log statement to only execute when an overload condition is detected.

No functional behavior was changed — this is purely a logging cleanup to improve log accuracy.