### PR TITLE
Scan project and replace rowIndex with primary keys

### DIFF
--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-components/header-actions-delete.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-components/header-actions-delete.tsx
@@ -25,19 +25,13 @@ export function HeaderActionsDelete({ table, schema, database }: { table: string
   const selected = useStore(store, state => state.selected)
   const { data: primaryKeys } = usePrimaryKeysQuery(database, table, schema)
 
+  // selectedRows is now just the selected primary key objects directly from the store
   const selectedRows = useMemo(() => {
-    if (!primaryKeys?.length || !rows)
+    if (!primaryKeys?.length) {
       return []
-
-    return selected.map((index) => {
-      const row = rows[index]
-
-      return primaryKeys.reduce((acc, key) => {
-        acc[key] = row[key]
-        return acc
-      }, {} as Record<string, unknown>)
-    })
-  }, [selected, primaryKeys, rows])
+    }
+    return selected // selected is already an array of primary key objects
+  }, [selected, primaryKeys])
 
   const { mutate: deleteRows, isPending: isDeleting } = useMutation({
     mutationFn: async () => {

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-lib/constants.ts
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-lib/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Constants for table components
+ */
+
+export const selectSymbol = Symbol('table-selection')
+
+export const columnsSizeMap = new Map<string, number>([
+  ['boolean', 150],
+  ['number', 150],
+  ['integer', 120],
+  ['bigint', 160],
+  ['timestamp', 240],
+  ['timestamptz', 240],
+  ['float', 150],
+  ['uuid', 290],
+])
+
+export const DEFAULT_COLUMN_WIDTH = 200

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-lib/primary-keys.ts
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/-lib/primary-keys.ts
@@ -1,0 +1,74 @@
+/**
+ * Utility functions for working with primary keys in table selection
+ */
+
+/**
+ * Extract primary key object from a row
+ */
+export function extractPrimaryKey(row: Record<string, unknown>, primaryKeys: string[]): Record<string, unknown> {
+  return primaryKeys.reduce((acc, key) => {
+    acc[key] = row[key]
+    return acc
+  }, {} as Record<string, unknown>)
+}
+
+/**
+ * Check if two primary key objects are equal
+ */
+export function arePrimaryKeysEqual(pk1: Record<string, unknown>, pk2: Record<string, unknown>): boolean {
+  const keys1 = Object.keys(pk1)
+  const keys2 = Object.keys(pk2)
+  
+  if (keys1.length !== keys2.length) {
+    return false
+  }
+  
+  return keys1.every(key => pk1[key] === pk2[key])
+}
+
+/**
+ * Find row index from primary key object
+ */
+export function findRowIndexByPrimaryKey(
+  rows: Record<string, unknown>[],
+  primaryKey: Record<string, unknown>,
+  primaryKeys: string[]
+): number {
+  return rows.findIndex(row => {
+    const rowPk = extractPrimaryKey(row, primaryKeys)
+    return arePrimaryKeysEqual(rowPk, primaryKey)
+  })
+}
+
+/**
+ * Check if a primary key is in a list of selected primary keys
+ */
+export function isPrimaryKeySelected(
+  primaryKey: Record<string, unknown>,
+  selectedPrimaryKeys: Record<string, unknown>[]
+): boolean {
+  return selectedPrimaryKeys.some(selected => arePrimaryKeysEqual(selected, primaryKey))
+}
+
+/**
+ * Add a primary key to the selected list if not already present
+ */
+export function addPrimaryKeyToSelection(
+  selectedPrimaryKeys: Record<string, unknown>[],
+  primaryKey: Record<string, unknown>
+): Record<string, unknown>[] {
+  if (isPrimaryKeySelected(primaryKey, selectedPrimaryKeys)) {
+    return selectedPrimaryKeys
+  }
+  return [...selectedPrimaryKeys, primaryKey]
+}
+
+/**
+ * Remove a primary key from the selected list
+ */
+export function removePrimaryKeyFromSelection(
+  selectedPrimaryKeys: Record<string, unknown>[],
+  primaryKey: Record<string, unknown>
+): Record<string, unknown>[] {
+  return selectedPrimaryKeys.filter(selected => !arePrimaryKeysEqual(selected, primaryKey))
+}

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/index.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/tables.$schema/$table/index.tsx
@@ -36,7 +36,7 @@ export function getTableStoreState(schema: string, table: string) {
 }
 
 interface PageStore {
-  selected: number[]
+  selected: Record<string, unknown>[] // Changed from number[] to primary key objects
   filters: WhereFilter[]
   hiddenColumns: string[]
   orderBy: Record<string, 'ASC' | 'DESC'>


### PR DESCRIPTION
## Description of Changes

-   **What was changed?**
    *   The table selection mechanism was refactored to use primary keys instead of row indices.
    *   The `PageStore`'s `selected` state now stores primary key objects (`Record<string, unknown>[]`).
    *   New utility functions for extracting, comparing, and managing primary keys in selection were added (`-lib/primary-keys.ts`).
    *   `SelectionHeaderCell` and `SelectionCell` components were updated to leverage primary key-based selection logic.
    *   `setValue` and `saveValue` functions in `TableComponent` now operate directly with primary key objects, with an adapter layer added to `TableCell` props for backward compatibility.
    *   Shared table constants were extracted into a new file (`-lib/constants.ts`).
    *   The `selectedRows` logic in `header-actions-delete.tsx` was simplified to directly use primary key objects.
-   **Why was it changed?**
    *   To ensure stable and reliable row selection and data manipulation (edit/delete) across pagination, filtering, and sorting. Using `rowIndex` is inherently unstable as row positions can change, leading to incorrect targeting of data. Primary keys provide a persistent and unique identifier for each row.
-   **Any related issues or discussions?**
    *   N/A

## Checklist

-   [ ] My changes are scoped and focused
-   [ ] I have tested the code locally

## Notes to reviewer

-   Please review the new primary key utility functions in `-lib/primary-keys.ts`.
-   Note the adapter layer implemented in `TableComponent`'s `TableCell` props (`onSetValue`, `onSaveValue`) to convert `rowIndex` to primary keys for existing components.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccf3701e-c699-424f-ad41-611cd2c7aa70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccf3701e-c699-424f-ad41-611cd2c7aa70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

