### PR TITLE
feat: add cascade option to drop table dialog

### DIFF
--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/drop-table-dialog.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/drop-table-dialog.tsx
@@ -2,6 +2,7 @@ import type { databases } from '~/drizzle'
 import { dropTableSql } from '@conar/shared/sql/drop-table'
 import { Alert, AlertDescription, AlertTitle } from '@conar/ui/components/alert'
 import { Button } from '@conar/ui/components/button'
+import { Checkbox } from '@conar/ui/components/checkbox'
 import { LoadingContent } from '@conar/ui/components/custom/loading-content'
 import {
   Dialog,
@@ -38,6 +39,7 @@ export function DropTableDialog({ ref, database }: DropTableDialogProps) {
   const [schema, setSchema] = useState('')
   const [table, setTable] = useState('')
   const [open, setOpen] = useState(false)
+  const [cascade, setCascade] = useState(false)
   const isCurrentTable = schema === schemaFromSearch && table === tableFromSearch
 
   useImperativeHandle(ref, () => ({
@@ -45,6 +47,7 @@ export function DropTableDialog({ ref, database }: DropTableDialogProps) {
       setSchema(schema)
       setTable(table)
       setConfirmationText('')
+      setCascade(false)
       setOpen(true)
     },
   }))
@@ -54,13 +57,14 @@ export function DropTableDialog({ ref, database }: DropTableDialogProps) {
       await dbQuery({
         type: database.type,
         connectionString: database.connectionString,
-        query: dropTableSql(schema, table)[database.type],
+        query: dropTableSql(schema, table, cascade)[database.type],
       })
     },
     onSuccess: () => {
       toast.success(`Table "${table}" successfully dropped`)
       setOpen(false)
       setConfirmationText('')
+      setCascade(false)
 
       queryClient.invalidateQueries(tablesAndSchemasQuery({ database }))
       closeTab(database.id, schema, table)
@@ -114,13 +118,26 @@ export function DropTableDialog({ ref, database }: DropTableDialogProps) {
                 autoComplete="off"
               />
             </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="cascade"
+                checked={cascade}
+                onCheckedChange={() => setCascade(!cascade)}
+              />
+              <Label htmlFor="cascade" className="font-normal">
+                Drop tables that depend on this table (CASCADE)
+              </Label>
+            </div>
           </div>
         </DialogHeader>
         <DialogFooter className="mt-4 flex gap-2">
           <DialogClose asChild>
             <Button
               variant="outline"
-              onClick={() => setConfirmationText('')}
+              onClick={() => {
+                setConfirmationText('')
+                setCascade(false)
+              }}
             >
               Cancel
             </Button>

--- a/packages/shared/src/sql/drop-table.ts
+++ b/packages/shared/src/sql/drop-table.ts
@@ -1,8 +1,9 @@
 import type { DatabaseType } from '@conar/shared/enums/database-type'
 import { prepareSql } from '@conar/shared/utils/helpers'
 
-export function dropTableSql(schema: string, table: string): Record<DatabaseType, string> {
+export function dropTableSql(schema: string, table: string, cascade = false): Record<DatabaseType, string> {
+  const cascadeClause = cascade ? ' CASCADE' : ''
   return {
-    postgres: prepareSql(`DROP TABLE "${schema}"."${table}"`),
+    postgres: prepareSql(`DROP TABLE "${schema}"."${table}"${cascadeClause}`),
   }
 }


### PR DESCRIPTION
## Description of Changes
- What was changed?
  - Added CASCADE checkbox to the drop table modal dialog with clear labeling "Drop tables that depend on this table (CASCADE)"
  - Updated dropTableSql function in packages/shared/src/sql/drop-table.ts to accept an optional cascade parameter (defaults to false)
  - Modified SQL generation to append  CASCADE clause when the option is enabled

- Why was it changed?
  - Solves dependency blocking issue: Currently users cannot drop tables that have dependent tables (foreign key references, views, etc.)
  - Improves user experience: Provides a safe, explicit way to handle table dependencies without requiring manual SQL commands
  - Maintains safety: Checkbox defaults to unchecked, requiring explicit user consent for cascade operations
  - Follows PostgreSQL standards: Uses the standard DROP TABLE ... CASCADE syntax

- Any related issues or discussions?
 - No


Closes #109 
- https://github.com/wannabespace/conar/issues/109

## Checklist

- [x] My changes are scoped and focused
- [ ] I have tested the code locally

## Notes to reviewer

- Are there any specific things the reviewer should focus on?
