### PR TITLE
fix: only highlight the correct database - table group

### DIFF
--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/tables-tree.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/tables-tree.tsx
@@ -60,7 +60,7 @@ interface TableItemProps {
 }
 
 function TableItem({ schema, table, isPinned = false, search, onRename, onDrop }: TableItemProps) {
-  const { table: tableParam } = useSearch({ from: '/(protected)/_protected/database/$id/table/' })
+  const { table: tableParam, schema: schemaParam } = useSearch({ from: '/(protected)/_protected/database/$id/table/' })
   const { database } = Route.useRouteContext()
 
   return (
@@ -75,7 +75,7 @@ function TableItem({ schema, table, isPinned = false, search, onRename, onDrop }
       onDoubleClick={() => addTab(database.id, schema, table)}
       className={cn(
         'group w-full flex items-center gap-2 border border-transparent py-1 px-2 text-sm text-foreground rounded-md hover:bg-accent/30',
-        tableParam === table && 'bg-primary/10 hover:bg-primary/20 border-primary/20',
+        tableParam === table && schemaParam === schema && 'bg-primary/10 hover:bg-primary/20 border-primary/20',
       )}
     >
       <RiTableLine


### PR DESCRIPTION
## Description of Changes

Adds a boolean check for the highlighting of the current table in the sidebar's search to prevent multiple databases having the same table being highlighted (i can't english rn but picture explains better anyway:)
before:
<img width="346" height="581" alt="image" src="https://github.com/user-attachments/assets/b8bcff9e-d2d2-4169-952c-e4e8b31a82bf" />
after:
<img width="344" height="572" alt="image" src="https://github.com/user-attachments/assets/68b4abf2-ffc9-4b2e-a566-a85a1df09915" />

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally