### PR TITLE
feat: use pg_class reltuples for fast row count estimate

### DIFF
--- a/apps/desktop/src/components/table/header.tsx
+++ b/apps/desktop/src/components/table/header.tsx
@@ -33,11 +33,13 @@ const VirtualHeaderColumn = memo(function VirtualHeaderColumn({
       key={virtualColumn.key}
       id={column.id}
       columnIndex={virtualColumn.index}
-      position={virtualColumn.index === 0
-        ? 'first'
-        : virtualColumn.index === columns.length - 1
-          ? 'last'
-          : 'middle'}
+      position={
+        virtualColumn.index === 0
+          ? 'first'
+          : virtualColumn.index === columns.length - 1
+            ? 'last'
+            : 'middle'
+      }
       size={virtualColumn.size}
       style={{
         width: `${virtualColumn.size}px`,
@@ -67,7 +69,10 @@ export function TableHeader({
 
   return (
     <div
-      className={cn('sticky top-0 z-10 border-y bg-background h-8 has-[[data-footer]]:h-12 w-fit min-w-full', className)}
+      className={cn(
+        'sticky top-0 z-10 border-y bg-background h-8 has-[[data-footer]]:h-12 w-fit min-w-full',
+        className,
+      )}
       style={{ width: `${tableWidth}px`, ...style }}
       {...props}
     >

--- a/apps/desktop/src/entities/database/query.ts
+++ b/apps/desktop/src/entities/database/query.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ts/no-explicit-any */
 import type { DatabaseType } from '@conar/shared/enums/database-type'
 import type { Type } from 'arktype'
 import type { databases } from '~/drizzle'
@@ -14,9 +15,7 @@ export function createQuery<P = undefined, T extends Type = Type<unknown>>(optio
   return {
     run: async (...p: [database: typeof databases.$inferSelect, ...(P extends undefined ? [] : [P])]): Promise<T extends Type ? T['inferOut'] : unknown> => {
       const [database, params] = p
-      // eslint-disable-next-line ts/no-explicit-any
       const result = await options.query(params)[database.type](dialects[database.type](database) as any)
-
       try {
         return options.type
           ? options.type.assert(result) as T extends Type ? T['inferOut'] : unknown

--- a/apps/desktop/src/entities/database/sql/total.ts
+++ b/apps/desktop/src/entities/database/sql/total.ts
@@ -1,74 +1,144 @@
-import type { ActiveFilter } from '@conar/shared/filters'
+/* eslint-disable ts/no-explicit-any */
+import type { ActiveFilter, Filter } from '@conar/shared/filters'
 import { type } from 'arktype'
 import { sql } from 'kysely'
 import { createQuery } from '../query'
 import { buildWhere } from './rows'
 
+const DEFAULT_THRESHOLD = 50_000
+
 export const totalQuery = createQuery({
-  type: type('string | number | bigint | undefined').pipe(v => v !== undefined ? Number(v) : undefined),
+  type: type({
+    count: 'number',
+    isEstimated: 'boolean',
+  }),
+
   query: ({
     schema,
     table,
     filters,
     enforceExactCount = false,
-  }: { schema: string, table: string, filters?: ActiveFilter[], enforceExactCount?: boolean }) => ({
+  }: {
+    schema: string
+    table: string
+    filters?: ActiveFilter<Filter>[]
+    enforceExactCount?: boolean
+  }) => ({
+
     postgres: async (db) => {
-      const THRESHOLD = 100_000
-      const estimate = await sql<{ reltuples: number }>`
-        SELECT reltuples
-        FROM pg_class
-        WHERE oid = ${sql.lit(`${schema}.${table}`)}::regclass
+      const estimate = await sql<{ row_estimate: number }>`
+        SELECT reltuples::bigint AS row_estimate
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ${schema}
+        AND c.relname = ${table}
       `.execute(db)
 
-      const estimatedRows = Number(estimate.rows[0]?.reltuples ?? 0)
-      const hasFilters = filters && filters.length > 0
-      const shouldUseEstimate = !enforceExactCount && estimatedRows > THRESHOLD && !hasFilters
+      const estimatedRows = Number(estimate.rows[0]?.row_estimate ?? 0)
+      const hasFilters = !!filters?.length
+
+      const shouldUseEstimate = !enforceExactCount && estimatedRows > DEFAULT_THRESHOLD && !hasFilters
 
       if (shouldUseEstimate) {
-        return estimatedRows
+        return { count: estimatedRows, isEstimated: true }
       }
 
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(!!filters?.length, qb => qb.where((eb: any) => buildWhere(eb, filters!)),
+        )
         .execute()
-      return query[0]?.total
+
+      return {
+        count: Number(query[0]?.total ?? 0),
+        isEstimated: false,
+      }
     },
+
     mysql: async (db) => {
+      const estimate = await sql<{ table_rows: number }>`
+        SELECT table_rows
+        FROM information_schema.tables
+        WHERE table_schema = ${schema}
+        AND table_name = ${table}
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && estimatedRows > DEFAULT_THRESHOLD && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(!!filters?.length, qb => qb.where((eb: any) => buildWhere(eb, filters!)),
+        )
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
+
     mssql: async (db) => {
+      const estimate = await sql<{ estimated_rows: number }>`
+        SELECT SUM(p.rows) AS estimated_rows
+        FROM sys.tables t
+        INNER JOIN sys.partitions p
+          ON t.object_id = p.object_id
+        INNER JOIN sys.schemas s
+          ON t.schema_id = s.schema_id
+        WHERE s.name = ${schema}
+        AND p.index_id IN (0, 1)
+        AND t.name = ${table}
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.estimated_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && estimatedRows > DEFAULT_THRESHOLD && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(!!filters?.length, qb => qb.where((eb: any) => buildWhere(eb, filters!)),
+        )
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
+
     clickhouse: async (db) => {
+      const estimate = await sql<{ table_rows: number }>`
+        SELECT SUM(rows) AS table_rows
+        FROM system.parts
+        WHERE database = ${schema}
+        AND table = ${table}
+        AND active = 1
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(!!filters?.length, qb => qb.where((eb: any) => buildWhere(eb, filters!)),
+        )
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
   }),
 })

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/sql/-components/chat/chat-messages.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/sql/-components/chat/chat-messages.tsx
@@ -416,7 +416,7 @@ export function ChatMessages({ className }: ComponentProps<'div'>) {
 
   useEffect(() => {
     if (userMessageRef.current) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect, react-hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
       setPlaceholderHeight(
         (scrollRef.current?.offsetHeight || 0) - (userMessageRef.current?.offsetHeight || 0) - MESSAGES_GAP,
       )

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
@@ -1,0 +1,103 @@
+import NumberFlow from '@number-flow/react'
+import { RiCheckLine, RiHistoryLine, RiQuestionLine, RiRefreshLine } from '@remixicon/react'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { totalQuery } from '~/entities/database'
+import { Route } from '../index'
+
+interface TableRowCounterProps {
+  schema: string
+  table: string
+  total?: number
+  isEstimated?: boolean
+  isLoading?: boolean
+}
+
+export function TableRowCounter({
+  schema,
+  table,
+  total,
+  isEstimated: initialIsEstimated,
+  isLoading: initialLoading,
+}: TableRowCounterProps) {
+  const { database } = Route.useLoaderData()
+  const [forceExact, setForceExact] = useState(false)
+
+  const { data, isLoading: queryLoading, isFetching } = useQuery({
+    queryKey: ['totalCount', database?.id, schema, table, forceExact],
+    queryFn: async () => {
+      return await totalQuery.run(database, {
+        schema,
+        table,
+        enforceExactCount: forceExact,
+      })
+    },
+    initialData: (total !== undefined)
+      ? { count: total, isEstimated: !!initialIsEstimated }
+      : undefined,
+    enabled: !!database?.id && !!table,
+    // If we are forcing exact, we want fresh data; otherwise, cache is fine
+    staleTime: forceExact ? 0 : 1000 * 60 * 5,
+  })
+
+  const handleToggleMode = () => {
+    setForceExact(prev => !prev)
+  }
+
+  const activeLoading = initialLoading || (queryLoading && !data)
+
+  if (activeLoading)
+    return <span className="animate-pulse opacity-50 text-[11px]">...</span>
+
+  if (!data || data.count === undefined)
+    return null
+
+  return (
+    <div className="flex items-center gap-1 text-[11px] font-medium">
+      <NumberFlow
+        value={data.count}
+        format={{ notation: forceExact ? 'standard' : 'compact', compactDisplay: 'short', maximumFractionDigits: 1 }}
+        className="text-zinc-100 font-semibold"
+      />
+      <span className="text-muted-foreground mr-1">records</span>
+
+      <div className="flex items-center gap-1">
+        {data.isEstimated && !forceExact
+          ? (
+              <span className="text-muted-foreground opacity-60 font-normal">(estimated)</span>
+            )
+          : (<span title="Exact Count verified"><RiCheckLine className="size-3 text-green-500/60" /></span>
+            )}
+        <button
+          type="button"
+          onClick={handleToggleMode}
+          disabled={isFetching}
+          title={forceExact ? 'Back to estimated count' : 'Get exact count'}
+          className="p-0.5 hover:bg-white/5 rounded-sm transition-colors group"
+        >
+          {forceExact
+            ? (
+                <RiHistoryLine
+                  className={`size-3 text-blue-400/70 group-hover:opacity-100 ${
+                    isFetching ? 'animate-spin' : ''
+                  }`}
+                />
+              )
+            : (
+                <RiRefreshLine
+                  className={`size-3 text-muted-foreground opacity-40 group-hover:opacity-100 ${
+                    isFetching ? 'animate-spin' : ''
+                  }`}
+                />
+              )}
+        </button>
+      </div>
+
+      {!data.isEstimated && (
+        <span title="The database returned an exact row count" className="cursor-help ml-0.5">
+          <RiQuestionLine className="size-3 text-zinc-500/40" />
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
@@ -1,10 +1,10 @@
 import { Separator } from '@conar/ui/components/separator'
-import NumberFlow from '@number-flow/react'
 import { useStore } from '@tanstack/react-store'
 import { useDatabaseTableTotal } from '~/entities/database'
 import { Route } from '..'
 import { useTableColumns } from '../-queries/use-columns-query'
 import { usePageStoreContext } from '../-store'
+import { TableRowCounter } from './estimate-row'
 import { HeaderActions } from './header-actions'
 import { HeaderSearch } from './header-search'
 
@@ -13,10 +13,8 @@ export function Header({ table, schema }: { table: string, schema: string }) {
   const columns = useTableColumns({ database, table, schema })
   const store = usePageStoreContext()
   const filters = useStore(store, state => state.filters)
-  const { data: total } = useDatabaseTableTotal({ database, table, schema, query: { filters } })
-
+  const { data: totalData, isLoading } = useDatabaseTableTotal({ database, table, schema, query: { filters } })
   const columnsCount = columns?.length ?? 0
-
   return (
     <div className="flex gap-6 w-full items-center justify-between">
       <div className="flex flex-1 gap-4 items-center">
@@ -30,29 +28,12 @@ export function Header({ table, schema }: { table: string, schema: string }) {
             {' '}
             <span data-mask>{table}</span>
           </h2>
-          <p className="text-muted-foreground text-xs">
-            <span className="tabular-nums">{columnsCount}</span>
-            {' '}
-            column
-            {columnsCount === 1 ? '' : 's'}
-            {' '}
-            •
-            {' '}
-            {total !== undefined
-              ? (
-                  <NumberFlow
-                    className="tabular-nums"
-                    value={total}
-                    style={{
-                      '--number-flow-mask-height': '0px',
-                    }}
-                  />
-                )
-              : <span className="animate-pulse">...</span>}
-            {' '}
-            row
-            {total !== undefined && total !== 1 && 's'}
-          </p>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="tabular-nums font-semibold text-zinc-300">{columnsCount}</span>
+            <span>columns</span>
+            <span className="text-muted-foreground opacity-30">•</span>
+            <TableRowCounter schema={schema} table={table} total={totalData?.count} isEstimated={totalData?.isEstimated} isLoading={isLoading} />
+          </div>
         </div>
         <Separator orientation="vertical" className="h-6!" />
         <HeaderSearch table={table} schema={schema} />

--- a/packages/ui/src/theme-observer.tsx
+++ b/packages/ui/src/theme-observer.tsx
@@ -51,7 +51,6 @@ export function ThemeObserver({
   storageKey = 'conar.theme',
 }: ThemeObserverProps) {
   if (!themeStore) {
-    // eslint-disable-next-line react-hooks/globals
     themeStore = new Store<ThemeStoreState>({
       theme: (isBrowser && (localStorage.getItem(storageKey) as Theme)) || defaultTheme,
       resolvedTheme: 'light',


### PR DESCRIPTION
The change adds a fast row count estimation for Postgres tables using
pg_class.reltuples when filters are not applied and exact counts are not enforced.

Falls back to COUNT(*) when:
1 filters are present, or
2enforceExactCount is true, or
3 estimated rows are below the threshold.


