### PR TITLE
feat(desktop): estimate and exact count ui toggle

### DIFF
--- a/apps/desktop/src/entities/database/sql/total.ts
+++ b/apps/desktop/src/entities/database/sql/total.ts
@@ -4,115 +4,134 @@ import { sql } from 'kysely'
 import { createQuery } from '../query'
 import { buildWhere } from './rows'
 
-const ESTIMATE_THRESHOLD = 50_000
+interface TotalQueryParams {
+  schema: string
+  table: string
+  filters?: ActiveFilter<Filter>[]
+  enforceExactCount?: boolean
+}
 
-export const totalQuery = createQuery({
+export const totalQuery = createQuery<TotalQueryParams>({
   type: type({
     count: 'number',
     isEstimated: 'boolean',
   }),
 
-  query: ({ schema, table, filters, enforceExactCount = false }: {
-    schema: string
-    table: string
-    filters?: ActiveFilter<Filter>[]
-    enforceExactCount?: boolean
-  }) => ({
+  query: ({ schema, table, filters = [], enforceExactCount = false }) => ({
     postgres: async (db) => {
-      const estimate = await sql<{ row_estimate: number }>`
-        SELECT reltuples::bigint AS row_estimate
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = ${schema} AND c.relname = ${table}
-      `.execute(db)
+      const hasFilters = filters.length > 0
 
-      const estimatedRows = Number(estimate.rows[0]?.row_estimate ?? 0)
-      const hasFilters = !!filters?.length
+      if (!enforceExactCount && !hasFilters) {
+        let estimatedRows = 0
+        try {
+          const estimate = await sql<{ row_estimate: number }>`
+            SELECT reltuples::bigint AS row_estimate
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = ${schema}
+              AND c.relname = ${table}
+          `.execute(db)
 
-      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
-        return { count: estimatedRows, isEstimated: true }
+          // Clamp negative or invalid estimates to 0
+          estimatedRows = Math.max(0, Number(estimate.rows[0]?.row_estimate ?? 0))
+        }
+        catch {
+          estimatedRows = 0
+        }
+
+        return {
+          count: estimatedRows,
+          isEstimated: true,
+        }
       }
 
-      const query = await db
-        .withSchema(schema)
-        .selectFrom(table as any)
+      // Only do exact count if forced or has filters
+      const result = await db
+        .selectFrom(sql`${sql.ref(schema)}.${sql.ref(table)}`.as('t'))
         .select(db.fn.countAll().as('total'))
-        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
+        .$if(hasFilters, qb => qb.where(eb => buildWhere(eb, filters)))
         .execute()
 
-      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
+      return {
+        count: Number(result[0]?.total ?? 0),
+        isEstimated: false,
+      }
     },
 
     mysql: async (db) => {
-      const estimate = await sql<{ table_rows: number }>`
-        SELECT table_rows FROM information_schema.tables
-        WHERE table_schema = ${schema} AND table_name = ${table}
-      `.execute(db)
+      const hasFilters = filters.length > 0
 
-      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
-      const hasFilters = !!filters?.length
+      if (!enforceExactCount && !hasFilters) {
+        const estimate = await sql<{ table_rows: number }>`
+          SELECT table_rows
+          FROM information_schema.tables
+          WHERE table_schema = ${schema}
+            AND table_name = ${table}
+        `.execute(db)
 
-      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
+        const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
         return { count: estimatedRows, isEstimated: true }
       }
 
-      const query = await db
-        .withSchema(schema)
-        .selectFrom(table as any)
+      const result = await db
+        .selectFrom(sql`${sql.ref(schema)}.${sql.ref(table)}`.as('t'))
         .select(db.fn.countAll().as('total'))
-        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
+        .$if(hasFilters, qb => qb.where(eb => buildWhere(eb, filters)))
         .execute()
 
-      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
+      return { count: Number(result[0]?.total ?? 0), isEstimated: false }
     },
 
     mssql: async (db) => {
-      const estimate = await sql<{ estimated_rows: number }>`
-        SELECT SUM(p.rows) AS estimated_rows
-        FROM sys.tables t
-        INNER JOIN sys.partitions p ON t.object_id = p.object_id
-        INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
-        WHERE s.name = ${schema} AND p.index_id IN (0, 1) AND t.name = ${table}
-      `.execute(db)
+      const hasFilters = filters.length > 0
 
-      const estimatedRows = Number(estimate.rows[0]?.estimated_rows ?? 0)
-      const hasFilters = !!filters?.length
+      if (!enforceExactCount && !hasFilters) {
+        const estimate = await sql<{ estimated_rows: number }>`
+          SELECT SUM(p.rows) AS estimated_rows
+          FROM sys.tables t
+          JOIN sys.partitions p ON t.object_id = p.object_id
+          JOIN sys.schemas s ON t.schema_id = s.schema_id
+          WHERE s.name = ${schema}
+            AND t.name = ${table}
+            AND p.index_id IN (0,1)
+        `.execute(db)
 
-      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
+        const estimatedRows = Number(estimate.rows[0]?.estimated_rows ?? 0)
         return { count: estimatedRows, isEstimated: true }
       }
 
-      const query = await db
-        .withSchema(schema)
-        .selectFrom(table as any)
+      const result = await db
+        .selectFrom(sql`${sql.ref(schema)}.${sql.ref(table)}`.as('t'))
         .select(db.fn.countAll().as('total'))
-        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
+        .$if(hasFilters, qb => qb.where(eb => buildWhere(eb, filters)))
         .execute()
 
-      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
+      return { count: Number(result[0]?.total ?? 0), isEstimated: false }
     },
 
     clickhouse: async (db) => {
-      const estimate = await sql<{ table_rows: number }>`
-        SELECT SUM(rows) AS table_rows FROM system.parts
-        WHERE database = ${schema} AND table = ${table} AND active = 1
-      `.execute(db)
-
-      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
-      const hasFilters = !!filters?.length
+      const hasFilters = filters.length > 0
 
       if (!enforceExactCount && !hasFilters) {
+        const estimate = await sql<{ table_rows: number }>`
+          SELECT SUM(rows) AS table_rows
+          FROM system.parts
+          WHERE database = ${schema}
+            AND table = ${table}
+            AND active = 1
+        `.execute(db)
+
+        const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
         return { count: estimatedRows, isEstimated: true }
       }
 
-      const query = await db
-        .withSchema(schema)
-        .selectFrom(table as any)
+      const result = await db
+        .selectFrom(sql`${sql.ref(schema)}.${sql.ref(table)}`.as('t'))
         .select(db.fn.countAll().as('total'))
-        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
+        .$if(hasFilters, qb => qb.where(eb => buildWhere(eb, filters)))
         .execute()
 
-      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
+      return { count: Number(result[0]?.total ?? 0), isEstimated: false }
     },
   }),
 })

--- a/apps/desktop/src/entities/database/sql/total.ts
+++ b/apps/desktop/src/entities/database/sql/total.ts
@@ -1,58 +1,118 @@
-import type { ActiveFilter } from '@conar/shared/filters'
+import type { ActiveFilter, Filter } from '@conar/shared/filters'
 import { type } from 'arktype'
+import { sql } from 'kysely'
 import { createQuery } from '../query'
 import { buildWhere } from './rows'
 
+const ESTIMATE_THRESHOLD = 50_000
+
 export const totalQuery = createQuery({
-  type: type('string | number | bigint | undefined').pipe(v => v !== undefined ? Number(v) : undefined),
-  query: ({
-    schema,
-    table,
-    filters,
-  }: { schema: string, table: string, filters?: ActiveFilter[] }) => ({
+  type: type({
+    count: 'number',
+    isEstimated: 'boolean',
+  }),
+
+  query: ({ schema, table, filters, enforceExactCount = false }: {
+    schema: string
+    table: string
+    filters?: ActiveFilter<Filter>[]
+    enforceExactCount?: boolean
+  }) => ({
     postgres: async (db) => {
+      const estimate = await sql<{ row_estimate: number }>`
+        SELECT reltuples::bigint AS row_estimate
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ${schema} AND c.relname = ${table}
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.row_estimate ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
+
     mysql: async (db) => {
+      const estimate = await sql<{ table_rows: number }>`
+        SELECT table_rows FROM information_schema.tables
+        WHERE table_schema = ${schema} AND table_name = ${table}
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
+
     mssql: async (db) => {
+      const estimate = await sql<{ estimated_rows: number }>`
+        SELECT SUM(p.rows) AS estimated_rows
+        FROM sys.tables t
+        INNER JOIN sys.partitions p ON t.object_id = p.object_id
+        INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+        WHERE s.name = ${schema} AND p.index_id IN (0, 1) AND t.name = ${table}
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.estimated_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && estimatedRows > ESTIMATE_THRESHOLD && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
+
     clickhouse: async (db) => {
+      const estimate = await sql<{ table_rows: number }>`
+        SELECT SUM(rows) AS table_rows FROM system.parts
+        WHERE database = ${schema} AND table = ${table} AND active = 1
+      `.execute(db)
+
+      const estimatedRows = Number(estimate.rows[0]?.table_rows ?? 0)
+      const hasFilters = !!filters?.length
+
+      if (!enforceExactCount && !hasFilters) {
+        return { count: estimatedRows, isEstimated: true }
+      }
+
       const query = await db
         .withSchema(schema)
-        .withTables<{ [table]: Record<string, unknown> }>()
-        .selectFrom(table)
+        .selectFrom(table as any)
         .select(db.fn.countAll().as('total'))
-        .$if(filters !== undefined, qb => qb.where(eb => buildWhere(eb, filters!)))
+        .$if(hasFilters, (qb: any) => qb.where((eb: any) => buildWhere(eb, filters!)))
         .execute()
 
-      return query[0]?.total
+      return { count: Number(query[0]?.total ?? 0), isEstimated: false }
     },
   }),
 })

--- a/apps/desktop/src/entities/database/sql/total.ts
+++ b/apps/desktop/src/entities/database/sql/total.ts
@@ -32,7 +32,6 @@ export const totalQuery = createQuery<TotalQueryParams>({
               AND c.relname = ${table}
           `.execute(db)
 
-          // Clamp negative or invalid estimates to 0
           estimatedRows = Math.max(0, Number(estimate.rows[0]?.row_estimate ?? 0))
         }
         catch {
@@ -45,7 +44,6 @@ export const totalQuery = createQuery<TotalQueryParams>({
         }
       }
 
-      // Only do exact count if forced or has filters
       const result = await db
         .selectFrom(sql`${sql.ref(schema)}.${sql.ref(table)}`.as('t'))
         .select(db.fn.countAll().as('total'))

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
@@ -1,97 +1,58 @@
 import NumberFlow from '@number-flow/react'
-import { RiCheckLine, RiHistoryLine, RiRefreshLine } from '@remixicon/react'
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
 import { totalQuery } from '~/entities/database'
 import { Route } from '../index'
 
 interface TableRowCounterProps {
   schema: string
   table: string
-  total?: number
-  isEstimated?: boolean
-  isLoading?: boolean
 }
 
-export function TableRowCounter({
-  schema,
-  table,
-  total,
-  isEstimated: initialIsEstimated,
-  isLoading: initialLoading,
-}: TableRowCounterProps) {
+export function TableRowCounter({ schema, table }: TableRowCounterProps) {
   const { database } = Route.useLoaderData()
-  const [forceExact, setForceExact] = useState(false)
 
-  const { data, isLoading: queryLoading, isFetching } = useQuery({
-    queryKey: ['totalCount', database?.id, schema, table, forceExact],
-    queryFn: async () => {
-      return await totalQuery.run(database, {
+  const { data, isLoading } = useQuery<{
+    count: number
+    isEstimated: boolean
+  }>({
+    queryKey: ['totalCount', database?.id, schema, table],
+    queryFn: () =>
+      totalQuery.run(database, {
         schema,
         table,
-        enforceExactCount: forceExact,
-      })
-    },
-    initialData: (total !== undefined)
-      ? { count: total, isEstimated: !!initialIsEstimated }
-      : undefined,
-    enabled: !!database?.id && !!table,
-    staleTime: forceExact ? 0 : 1000 * 60 * 5,
+        enforceExactCount: false,
+      }) as Promise<{ count: number, isEstimated: boolean }>,
+    enabled: Boolean(database?.id && table),
+
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
   })
 
-  const handleToggleMode = () => setForceExact(prev => !prev)
-
-  const activeLoading = initialLoading || (queryLoading && !data)
-
-  if (activeLoading)
+  if (isLoading || !data) {
     return <span className="animate-pulse opacity-50 text-[11px]">...</span>
+  }
 
-  if (!data || data.count === undefined)
-    return null
+  const count = Number.isNaN(data.count) ? 0 : data.count
 
   return (
-    <div className="flex items-center gap-1 text-[11px] font-medium">
+    <span className="inline-flex items-center gap-1 text-[11px] font-medium">
       <NumberFlow
-        value={data.count}
+        value={count}
         format={{
-          notation: forceExact ? 'standard' : 'compact',
+          notation: 'compact',
           compactDisplay: 'short',
-          maximumFractionDigits: forceExact ? 0 : 1,
+          maximumFractionDigits: 1,
         }}
-        className="text-zinc-100 font-semibold"
+        className="text-zinc-100 font-semibold tabular-nums"
       />
-      <span className="text-muted-foreground mr-1">records</span>
-
-      <div className="flex items-center gap-1">
-        {data.isEstimated && !forceExact
-          ? (
-              <span className="text-muted-foreground opacity-60 font-normal">(estimated)</span>
-            )
-          : (
-              <span title="Exact count verified">
-                <RiCheckLine className="size-3 text-green-500/60" />
-              </span>
-            )}
-
-        <button
-          type="button"
-          onClick={handleToggleMode}
-          disabled={isFetching}
-          className="p-0.5 hover:bg-white/5 rounded-sm transition-colors group"
-        >
-          {forceExact
-            ? (
-                <RiHistoryLine className="size-3 text-blue-400/70" />
-              )
-            : (
-                <RiRefreshLine
-                  className={`size-3 text-muted-foreground opacity-40 group-hover:opacity-100 ${
-                    isFetching ? 'animate-spin' : ''
-                  }`}
-                />
-              )}
-        </button>
-      </div>
-    </div>
+      <span className="text-muted-foreground">records</span>
+      {data.isEstimated && (
+        <span className="text-muted-foreground opacity-60 font-normal">
+          (estimated)
+        </span>
+      )}
+    </span>
   )
 }

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/estimate-row.tsx
@@ -1,0 +1,97 @@
+import NumberFlow from '@number-flow/react'
+import { RiCheckLine, RiHistoryLine, RiRefreshLine } from '@remixicon/react'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { totalQuery } from '~/entities/database'
+import { Route } from '../index'
+
+interface TableRowCounterProps {
+  schema: string
+  table: string
+  total?: number
+  isEstimated?: boolean
+  isLoading?: boolean
+}
+
+export function TableRowCounter({
+  schema,
+  table,
+  total,
+  isEstimated: initialIsEstimated,
+  isLoading: initialLoading,
+}: TableRowCounterProps) {
+  const { database } = Route.useLoaderData()
+  const [forceExact, setForceExact] = useState(false)
+
+  const { data, isLoading: queryLoading, isFetching } = useQuery({
+    queryKey: ['totalCount', database?.id, schema, table, forceExact],
+    queryFn: async () => {
+      return await totalQuery.run(database, {
+        schema,
+        table,
+        enforceExactCount: forceExact,
+      })
+    },
+    initialData: (total !== undefined)
+      ? { count: total, isEstimated: !!initialIsEstimated }
+      : undefined,
+    enabled: !!database?.id && !!table,
+    staleTime: forceExact ? 0 : 1000 * 60 * 5,
+  })
+
+  const handleToggleMode = () => setForceExact(prev => !prev)
+
+  const activeLoading = initialLoading || (queryLoading && !data)
+
+  if (activeLoading)
+    return <span className="animate-pulse opacity-50 text-[11px]">...</span>
+
+  if (!data || data.count === undefined)
+    return null
+
+  return (
+    <div className="flex items-center gap-1 text-[11px] font-medium">
+      <NumberFlow
+        value={data.count}
+        format={{
+          notation: forceExact ? 'standard' : 'compact',
+          compactDisplay: 'short',
+          maximumFractionDigits: forceExact ? 0 : 1,
+        }}
+        className="text-zinc-100 font-semibold"
+      />
+      <span className="text-muted-foreground mr-1">records</span>
+
+      <div className="flex items-center gap-1">
+        {data.isEstimated && !forceExact
+          ? (
+              <span className="text-muted-foreground opacity-60 font-normal">(estimated)</span>
+            )
+          : (
+              <span title="Exact count verified">
+                <RiCheckLine className="size-3 text-green-500/60" />
+              </span>
+            )}
+
+        <button
+          type="button"
+          onClick={handleToggleMode}
+          disabled={isFetching}
+          className="p-0.5 hover:bg-white/5 rounded-sm transition-colors group"
+        >
+          {forceExact
+            ? (
+                <RiHistoryLine className="size-3 text-blue-400/70" />
+              )
+            : (
+                <RiRefreshLine
+                  className={`size-3 text-muted-foreground opacity-40 group-hover:opacity-100 ${
+                    isFetching ? 'animate-spin' : ''
+                  }`}
+                />
+              )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
@@ -1,10 +1,10 @@
 import { Separator } from '@conar/ui/components/separator'
-import NumberFlow from '@number-flow/react'
 import { useStore } from '@tanstack/react-store'
 import { useDatabaseTableTotal } from '~/entities/database'
 import { Route } from '..'
 import { useTableColumns } from '../-queries/use-columns-query'
 import { usePageStoreContext } from '../-store'
+import { TableRowCounter } from './estimate-row'
 import { HeaderActions } from './header-actions'
 import { HeaderSearch } from './header-search'
 
@@ -13,8 +13,12 @@ export function Header({ table, schema }: { table: string, schema: string }) {
   const columns = useTableColumns({ database, table, schema })
   const store = usePageStoreContext()
   const filters = useStore(store, state => state.filters)
-  const { data: total } = useDatabaseTableTotal({ database, table, schema, query: { filters } })
-
+  const { data: totalData, isLoading } = useDatabaseTableTotal({
+    database,
+    table,
+    schema,
+    query: { filters },
+  })
   const columnsCount = columns?.length ?? 0
 
   return (
@@ -22,37 +26,27 @@ export function Header({ table, schema }: { table: string, schema: string }) {
       <div className="flex flex-1 gap-4 items-center">
         <div className="shrink-0">
           <h2 className="font-medium text-sm mb-0.5 space-x-1">
-            <span className="text-muted-foreground">
-              {schema}
-            </span>
+            <span className="text-muted-foreground">{schema}</span>
             {' '}
             <span className="text-muted-foreground/20">/</span>
             {' '}
             <span data-mask>{table}</span>
           </h2>
-          <p className="text-muted-foreground text-xs">
-            <span className="tabular-nums">{columnsCount}</span>
-            {' '}
-            column
-            {columnsCount === 1 ? '' : 's'}
-            {' '}
-            •
-            {' '}
-            {total !== undefined
-              ? (
-                  <NumberFlow
-                    className="tabular-nums"
-                    value={total}
-                    style={{
-                      '--number-flow-mask-height': '0px',
-                    }}
-                  />
-                )
-              : <span className="animate-pulse">...</span>}
-            {' '}
-            row
-            {total !== undefined && total !== 1 && 's'}
-          </p>
+
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="tabular-nums font-semibold text-zinc-300">{columnsCount}</span>
+            <span>columns</span>
+            <span className="text-muted-foreground opacity-30">•</span>
+
+            {/* PASS THE DATA DOWN HERE */}
+            <TableRowCounter
+              schema={schema}
+              table={table}
+              total={totalData?.count}
+              isEstimated={totalData?.isEstimated}
+              isLoading={isLoading}
+            />
+          </div>
         </div>
         <Separator orientation="vertical" className="h-6!" />
         <HeaderSearch table={table} schema={schema} />

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/header.tsx
@@ -13,12 +13,8 @@ export function Header({ table, schema }: { table: string, schema: string }) {
   const columns = useTableColumns({ database, table, schema })
   const store = usePageStoreContext()
   const filters = useStore(store, state => state.filters)
-  const { data: totalData, isLoading } = useDatabaseTableTotal({
-    database,
-    table,
-    schema,
-    query: { filters },
-  })
+  const { data: _total } = useDatabaseTableTotal({ database, table, schema, query: { filters } })
+
   const columnsCount = columns?.length ?? 0
 
   return (
@@ -26,27 +22,24 @@ export function Header({ table, schema }: { table: string, schema: string }) {
       <div className="flex flex-1 gap-4 items-center">
         <div className="shrink-0">
           <h2 className="font-medium text-sm mb-0.5 space-x-1">
-            <span className="text-muted-foreground">{schema}</span>
+            <span className="text-muted-foreground">
+              {schema}
+            </span>
             {' '}
             <span className="text-muted-foreground/20">/</span>
             {' '}
             <span data-mask>{table}</span>
           </h2>
-
-          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-            <span className="tabular-nums font-semibold text-zinc-300">{columnsCount}</span>
-            <span>columns</span>
-            <span className="text-muted-foreground opacity-30">•</span>
-
-            {/* PASS THE DATA DOWN HERE */}
-            <TableRowCounter
-              schema={schema}
-              table={table}
-              total={totalData?.count}
-              isEstimated={totalData?.isEstimated}
-              isLoading={isLoading}
-            />
-          </div>
+          <p className="text-muted-foreground text-xs">
+            <span className="tabular-nums">{columnsCount}</span>
+            {' '}
+            column
+            {columnsCount === 1 ? '' : 's'}
+            {' '}
+            •
+            {' '}
+            <TableRowCounter schema={schema} table={table} />
+          </p>
         </div>
         <Separator orientation="vertical" className="h-6!" />
         <HeaderSearch table={table} schema={schema} />


### PR DESCRIPTION
Overview  - This PR adds the ability to view estimated row counts for PostgreSQL tables, significantly improving performance for large datasets where an exact count is not immediately necessary.

