### PR TITLE
feat: adds rename column ability

### DIFF
--- a/apps/desktop/electron/main/lib/events.ts
+++ b/apps/desktop/electron/main/lib/events.ts
@@ -1,5 +1,6 @@
 import type { DatabaseType } from '@conar/shared/enums/database-type'
 import { decrypt, encrypt } from '@conar/shared/encryption'
+import { tryParseJson } from '@conar/shared/utils/helpers'
 import { app, ipcMain } from 'electron'
 import { autoUpdater, sendToast } from '..'
 import { getClient as getClickhouseClient } from '../databases/clickhouse'
@@ -77,31 +78,43 @@ const queryMap = {
     return { result: result as unknown, duration: performance.now() - start! }
   },
   clickhouse: async ({ connectionString, sql }: { sql: string, connectionString: string, insertValues?: unknown[] }) => {
-    const client = getClickhouseClient(connectionString)
-    const isSelect = [
-      'SELECT',
-      'SHOW',
-      'DESCRIBE',
-      'EXPLAIN',
-      'WITH',
-      'CHECK',
-    ].some(keyword => sql.trim().toUpperCase().startsWith(keyword))
-    let start = 0
+    try {
+      const client = getClickhouseClient(connectionString)
+      const isSelect = [
+        'SELECT',
+        'SHOW',
+        'DESCRIBE',
+        'EXPLAIN',
+        'WITH',
+        'CHECK',
+      ].some(keyword => sql.trim().toUpperCase().startsWith(keyword))
+      let start = 0
 
-    if (isSelect) {
-      const result = await retryIfConnectionError(() => {
+      if (isSelect) {
+        const result = await retryIfConnectionError(() => {
+          start = performance.now()
+          return client.query({ query: sql, format: 'JSONEachRow' }).then(result => result.json())
+        })
+        return { result, duration: performance.now() - start }
+      }
+
+      await retryIfConnectionError(() => {
         start = performance.now()
-        return client.query({ query: sql, format: 'JSONEachRow' }).then(result => result.json())
+        return client.exec({ query: sql })
       })
-      return { result, duration: performance.now() - start }
+
+      return { result: [], duration: performance.now() - start }
     }
+    catch (error) {
+      if (error instanceof Error) {
+        const parsed = tryParseJson<Partial<{ message: string, status: string, code: number, request_id: string }>>(error.message)
 
-    await retryIfConnectionError(() => {
-      start = performance.now()
-      return client.exec({ query: sql })
-    })
-
-    return { result: [], duration: performance.now() - start }
+        if (parsed?.message) {
+          throw new Error(parsed.message)
+        }
+      }
+      throw error
+    }
   },
   mssql: async ({ connectionString, sql, values }: { sql: string, values: unknown[], connectionString: string }) => {
     let start = 0

--- a/apps/desktop/src/entities/database/dialects/clickhouse/schema/index.ts
+++ b/apps/desktop/src/entities/database/dialects/clickhouse/schema/index.ts
@@ -1,4 +1,5 @@
 import type { WithSchema } from '../../../utils/types'
 import type { InformationSchema } from './information'
+import type { SystemSchema } from './system'
 
-export type Database = WithSchema<InformationSchema, 'information_schema'>
+export type Database = WithSchema<InformationSchema, 'information_schema'> & WithSchema<SystemSchema, 'system'>

--- a/apps/desktop/src/entities/database/dialects/clickhouse/schema/index.ts
+++ b/apps/desktop/src/entities/database/dialects/clickhouse/schema/index.ts
@@ -1,5 +1,5 @@
 import type { WithSchema } from '../../../utils/types'
 import type { InformationSchema } from './information'
-import type { SystemSchema } from './system'
+import type { System } from './system'
 
-export type Database = WithSchema<InformationSchema, 'information_schema'> & WithSchema<SystemSchema, 'system'>
+export type Database = WithSchema<InformationSchema, 'information_schema'> & WithSchema<System, 'system'>

--- a/apps/desktop/src/entities/database/dialects/clickhouse/schema/system.ts
+++ b/apps/desktop/src/entities/database/dialects/clickhouse/schema/system.ts
@@ -2,7 +2,7 @@
  * @name system
  * @type schema
  */
-export interface SystemSchema {
+export interface System {
   columns: Columns
 }
 

--- a/apps/desktop/src/entities/database/dialects/clickhouse/schema/system.ts
+++ b/apps/desktop/src/entities/database/dialects/clickhouse/schema/system.ts
@@ -1,0 +1,18 @@
+/**
+ * @name system
+ * @type schema
+ */
+export interface SystemSchema {
+  columns: Columns
+}
+
+/**
+ * @name columns
+ * @type table
+ */
+interface Columns {
+  database: string
+  table: string
+  name: string
+  is_in_primary_key: number
+}

--- a/apps/desktop/src/entities/database/sql/columns.ts
+++ b/apps/desktop/src/entities/database/sql/columns.ts
@@ -186,3 +186,32 @@ export const columnsQuery = createQuery({
     },
   }),
 })
+
+export const renameColumnQuery = createQuery({
+  query: ({ schema, table, oldColumn, newColumn }: { schema: string, table: string, oldColumn: string, newColumn: string }) => ({
+    postgres: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+    mysql: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+    mssql: async (db) => {
+      await sql`EXEC sp_rename ${sql.val(`${schema}.${table}.${oldColumn}`)}, ${sql.val(newColumn)}, 'COLUMN'`.execute(db)
+    },
+    clickhouse: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+  }),
+})

--- a/apps/desktop/src/entities/database/sql/columns.ts
+++ b/apps/desktop/src/entities/database/sql/columns.ts
@@ -186,32 +186,3 @@ export const columnsQuery = createQuery({
     },
   }),
 })
-
-export const renameColumnQuery = createQuery({
-  query: ({ schema, table, oldColumn, newColumn }: { schema: string, table: string, oldColumn: string, newColumn: string }) => ({
-    postgres: db => db
-      .withSchema(schema)
-      .withTables<{ [table]: Record<string, unknown> }>()
-      .schema
-      .alterTable(table)
-      .renameColumn(oldColumn, newColumn)
-      .execute(),
-    mysql: db => db
-      .withSchema(schema)
-      .withTables<{ [table]: Record<string, unknown> }>()
-      .schema
-      .alterTable(table)
-      .renameColumn(oldColumn, newColumn)
-      .execute(),
-    mssql: async (db) => {
-      await sql`EXEC sp_rename ${sql.val(`${schema}.${table}.${oldColumn}`)}, ${sql.val(newColumn)}, 'COLUMN'`.execute(db)
-    },
-    clickhouse: db => db
-      .withSchema(schema)
-      .withTables<{ [table]: Record<string, unknown> }>()
-      .schema
-      .alterTable(table)
-      .renameColumn(oldColumn, newColumn)
-      .execute(),
-  }),
-})

--- a/apps/desktop/src/entities/database/sql/constraints.ts
+++ b/apps/desktop/src/entities/database/sql/constraints.ts
@@ -99,9 +99,8 @@ export const constraintsQuery = createQuery({
       .where('tc.TABLE_SCHEMA', 'not in', ['INFORMATION_SCHEMA', 'sys'])
       .execute(),
     clickhouse: async (db) => {
-      // clickhouse generally doesnt support traditional constraints like foreign key but we can fetch primary keys
+      // Clickhouse generally doesn't support traditional constraints like foreign key but we can fetch primary keys
       const query = await db
-        .withTables<{ 'system.columns': { database: string, table: string, name: string, is_in_primary_key: number } }>()
         .selectFrom('system.columns')
         .select([
           'database as schema',

--- a/apps/desktop/src/entities/database/sql/rename-columns.ts
+++ b/apps/desktop/src/entities/database/sql/rename-columns.ts
@@ -1,0 +1,31 @@
+import { sql } from 'kysely'
+import { createQuery } from '../query'
+
+export const renameColumnQuery = createQuery({
+  query: ({ schema, table, oldColumn, newColumn }: { schema: string, table: string, oldColumn: string, newColumn: string }) => ({
+    postgres: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+    mysql: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+    mssql: async (db) => {
+      await sql`EXEC sp_rename ${sql.val(`${schema}.${table}.${oldColumn}`)}, ${sql.val(newColumn)}, 'COLUMN'`.execute(db)
+    },
+    clickhouse: db => db
+      .withSchema(schema)
+      .withTables<{ [table]: Record<string, unknown> }>()
+      .schema
+      .alterTable(table)
+      .renameColumn(oldColumn, newColumn)
+      .execute(),
+  }),
+})

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
@@ -16,6 +16,7 @@ import { RiInformationLine } from '@remixicon/react'
 import { useMutation } from '@tanstack/react-query'
 import { useImperativeHandle, useState } from 'react'
 import { toast } from 'sonner'
+import { databaseRowsQuery } from '~/entities/database'
 import { databaseTableColumnsQuery } from '~/entities/database/queries/columns'
 import { renameColumnQuery } from '~/entities/database/sql/rename-columns'
 import { queryClient } from '~/main'
@@ -59,7 +60,7 @@ export function RenameColumnDialog({ ref, database }: RenameColumnDialogProps) {
 
       await queryClient.invalidateQueries(databaseTableColumnsQuery({ database, table, schema }))
       await queryClient.invalidateQueries({
-        queryKey: ['database', database.id, 'schema', schema, 'table', table, 'rows'],
+        queryKey: databaseRowsQuery({ database, table, schema, query: { filters: [], orderBy: {} } }).queryKey.slice(0, -1),
       })
     },
     onError: (error) => {

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
@@ -17,7 +17,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useImperativeHandle, useState } from 'react'
 import { toast } from 'sonner'
 import { databaseTableColumnsQuery } from '~/entities/database/queries/columns'
-import { renameColumnQuery } from '~/entities/database/sql/columns'
+import { renameColumnQuery } from '~/entities/database/sql/rename-columns'
 import { queryClient } from '~/main'
 
 interface RenameColumnDialogProps {

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/rename-column-dialog.tsx
@@ -1,0 +1,135 @@
+import type { databases } from '~/drizzle'
+import { Alert, AlertDescription, AlertTitle } from '@conar/ui/components/alert'
+import { Button } from '@conar/ui/components/button'
+import { LoadingContent } from '@conar/ui/components/custom/loading-content'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@conar/ui/components/dialog'
+import { Input } from '@conar/ui/components/input'
+import { Label } from '@conar/ui/components/label'
+import { RiInformationLine } from '@remixicon/react'
+import { useMutation } from '@tanstack/react-query'
+import { useImperativeHandle, useState } from 'react'
+import { toast } from 'sonner'
+import { databaseTableColumnsQuery } from '~/entities/database/queries/columns'
+import { renameColumnQuery } from '~/entities/database/sql/columns'
+import { queryClient } from '~/main'
+
+interface RenameColumnDialogProps {
+  ref: React.RefObject<{
+    rename: (schema: string, table: string, column: string) => void
+  } | null>
+  database: typeof databases.$inferSelect
+}
+
+export function RenameColumnDialog({ ref, database }: RenameColumnDialogProps) {
+  const [newColumnName, setNewColumnName] = useState('')
+  const [schema, setSchema] = useState('')
+  const [table, setTable] = useState('')
+  const [column, setColumn] = useState('')
+  const [open, setOpen] = useState(false)
+
+  useImperativeHandle(ref, () => ({
+    rename: (schema: string, table: string, column: string) => {
+      setSchema(schema)
+      setTable(table)
+      setColumn(column)
+      setNewColumnName(column)
+      setOpen(true)
+    },
+  }))
+
+  const { mutate: renameColumn, isPending } = useMutation({
+    mutationFn: async () => {
+      await renameColumnQuery.run(database, {
+        schema,
+        table,
+        oldColumn: column,
+        newColumn: newColumnName,
+      })
+    },
+    onSuccess: async () => {
+      toast.success(`Column "${column}" successfully renamed to "${newColumnName}"`)
+      setOpen(false)
+
+      await queryClient.invalidateQueries(databaseTableColumnsQuery({ database, table, schema }))
+      await queryClient.invalidateQueries({
+        queryKey: ['database', database.id, 'schema', schema, 'table', table, 'rows'],
+      })
+    },
+    onError: (error) => {
+      toast.error(`Failed to rename column: ${error.message}`)
+    },
+  })
+
+  const canConfirm = newColumnName.trim() !== '' && newColumnName.trim() !== column && !isPending
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Rename Column
+          </DialogTitle>
+          <div className="space-y-4">
+            <Alert>
+              <RiInformationLine className="size-5 text-blue-500" />
+              <AlertTitle>
+                Rename column "
+                {column}
+                "
+              </AlertTitle>
+              <AlertDescription>
+                This will rename the column from "
+                {column}
+                " to the new name you specify.
+              </AlertDescription>
+            </Alert>
+            <div className="space-y-2">
+              <Label htmlFor="newColumnName" className="font-normal">
+                Column name
+              </Label>
+              <Input
+                id="newColumnName"
+                value={newColumnName}
+                placeholder="Enter new column name"
+                spellCheck={false}
+                autoComplete="off"
+                onChange={e => setNewColumnName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && canConfirm) {
+                    renameColumn()
+                  }
+                }}
+              />
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogFooter className="mt-4 flex gap-2">
+          <DialogClose asChild>
+            <Button variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            disabled={!canConfirm}
+            onClick={() => {
+              if (canConfirm) {
+                renameColumn()
+              }
+            }}
+          >
+            <LoadingContent loading={isPending}>
+              Rename Column
+            </LoadingContent>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table-header-cell.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table-header-cell.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@conar/ui/components/badge'
 import { Button } from '@conar/ui/components/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@conar/ui/components/tooltip'
 import { cn } from '@conar/ui/lib/utils'
-import { RiArrowDownLine, RiArrowUpDownLine, RiArrowUpLine, RiBookOpenLine, RiEraserLine, RiFingerprintLine, RiKey2Line, RiLinksLine } from '@remixicon/react'
+import { RiArrowDownLine, RiArrowUpDownLine, RiArrowUpLine, RiBookOpenLine, RiEraserLine, RiFingerprintLine, RiKey2Line, RiLinksLine, RiPencilLine } from '@remixicon/react'
 import { useQuery } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
 import { databaseEnumsQuery } from '~/entities/database'
@@ -47,6 +47,7 @@ function SortButton({ order, onClick }: { order: 'ASC' | 'DESC' | null, onClick:
 
 export function TableHeaderCell({
   onSort,
+  onRename,
   column,
   position,
   columnIndex,
@@ -55,6 +56,7 @@ export function TableHeaderCell({
 }: {
   column: Column
   onSort?: () => void
+  onRename?: () => void
   className?: string
 } & TableHeaderCellProps) {
   const { database } = Route.useLoaderData()
@@ -68,7 +70,7 @@ export function TableHeaderCell({
   return (
     <div
       className={cn(
-        'flex w-full items-center justify-between shrink-0 p-2',
+        'flex w-full shrink-0 items-center justify-between p-2',
         position === 'first' && 'pl-4',
         position === 'last' && 'pr-4',
         className,
@@ -78,13 +80,25 @@ export function TableHeaderCell({
       data-index={columnIndex}
       data-column-id={column.id}
     >
-      <div className="text-xs overflow-hidden">
+      <div className="overflow-hidden text-xs">
         <div
           data-mask
-          className="truncate font-medium flex items-center gap-1"
+          className={`
+            group/header-cell flex items-center gap-1 truncate font-medium
+          `}
           title={column.id}
         >
           {column.id}
+          {onRename && (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={onRename}
+              className="size-5 transition-opacity"
+            >
+              <RiPencilLine className="size-3 text-muted-foreground" />
+            </Button>
+          )}
         </div>
         {column?.type && (
           <div data-footer={!!column.type} className="flex items-center gap-1">
@@ -95,7 +109,7 @@ export function TableHeaderCell({
                     <RiKey2Line className="size-3 text-primary" />
                   </TooltipTrigger>
                   <TooltipContent>
-                    <div className="flex items-center gap-1 mb-1">
+                    <div className="mb-1 flex items-center gap-1">
                       <RiKey2Line className="size-3 text-primary" />
                       <span>Primary key</span>
                     </div>
@@ -125,11 +139,17 @@ export function TableHeaderCell({
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <RiFingerprintLine className="size-3 text-muted-foreground/70" />
+                    <RiFingerprintLine className={`
+                      size-3 text-muted-foreground/70
+                    `}
+                    />
                   </TooltipTrigger>
                   <TooltipContent>
-                    <div className="flex items-center gap-1 mb-1">
-                      <RiFingerprintLine className="size-3 text-muted-foreground/70" />
+                    <div className="mb-1 flex items-center gap-1">
+                      <RiFingerprintLine className={`
+                        size-3 text-muted-foreground/70
+                      `}
+                      />
                       <span>Unique</span>
                     </div>
                     <div className="text-xs text-muted-foreground">
@@ -147,7 +167,10 @@ export function TableHeaderCell({
                   </TooltipTrigger>
                   <TooltipContent>
                     <div className="flex items-center gap-1">
-                      <RiBookOpenLine className="size-3 text-muted-foreground/70" />
+                      <RiBookOpenLine className={`
+                        size-3 text-muted-foreground/70
+                      `}
+                      />
                       <span>Read only</span>
                     </div>
                   </TooltipContent>
@@ -183,7 +206,11 @@ export function TableHeaderCell({
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="text-muted-foreground truncate font-mono underline decoration-dotted">
+                        <span className={`
+                          truncate font-mono text-muted-foreground underline
+                          decoration-dotted
+                        `}
+                        >
                           {column.type}
                         </span>
                       </TooltipTrigger>
@@ -207,7 +234,7 @@ export function TableHeaderCell({
                   </TooltipProvider>
                 )
               : (
-                  <span className="text-muted-foreground truncate font-mono">
+                  <span className="truncate font-mono text-muted-foreground">
                     {column.type}
                   </span>
                 )}

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table-header-cell.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table-header-cell.tsx
@@ -70,7 +70,10 @@ export function TableHeaderCell({
   return (
     <div
       className={cn(
-        'flex w-full shrink-0 items-center justify-between p-2',
+        `
+          group/header-cell flex w-full shrink-0 items-center justify-between
+          p-2
+        `,
         position === 'first' && 'pl-4',
         position === 'last' && 'pr-4',
         className,
@@ -83,9 +86,7 @@ export function TableHeaderCell({
       <div className="overflow-hidden text-xs">
         <div
           data-mask
-          className={`
-            group/header-cell flex items-center gap-1 truncate font-medium
-          `}
+          className="flex items-center gap-1 truncate font-medium"
           title={column.id}
         >
           {column.id}
@@ -94,7 +95,10 @@ export function TableHeaderCell({
               variant="ghost"
               size="icon-xs"
               onClick={onRename}
-              className="size-5 transition-opacity"
+              className={`
+                size-5 opacity-0 transition-opacity
+                group-hover/header-cell:opacity-100
+              `}
             >
               <RiPencilLine className="size-3 text-muted-foreground" />
             </Button>

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
@@ -3,7 +3,7 @@ import type { Column } from '~/entities/database'
 import { SQL_FILTERS_LIST } from '@conar/shared/filters/sql'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { Table, TableBody, TableProvider } from '~/components/table'
 import { databaseRowsQuery, DEFAULT_COLUMN_WIDTH, DEFAULT_ROW_HEIGHT, selectQuery, setQuery } from '~/entities/database'
@@ -15,6 +15,7 @@ import { getColumnSize, selectSymbol } from '../-lib'
 import { useTableColumns } from '../-queries/use-columns-query'
 import { usePageStoreContext } from '../-store'
 import { useHeaderActionsOrder } from './header-actions-order'
+import { RenameColumnDialog } from './rename-column-dialog'
 import { TableEmpty } from './table-empty'
 import { TableHeader } from './table-header'
 import { TableHeaderCell } from './table-header-cell'
@@ -33,12 +34,19 @@ function prepareValue(value: unknown, column?: Column): unknown {
 
 export function TableError({ error }: { error: Error }) {
   return (
-    <div className="sticky left-0 pointer-events-none h-full flex items-center pb-10 justify-center">
-      <div className="flex flex-col items-center p-4 bg-card rounded-lg border max-w-md">
-        <div className="text-destructive mb-1">
+    <div className={`
+      pointer-events-none sticky left-0 flex h-full items-center justify-center
+      pb-10
+    `}
+    >
+      <div className={`
+        flex max-w-md flex-col items-center rounded-lg border bg-card p-4
+      `}
+      >
+        <div className="mb-1 text-destructive">
           Error occurred
         </div>
-        <p className="text-sm font-mono text-center text-muted-foreground">
+        <p className="text-center font-mono text-sm text-muted-foreground">
           {error.message}
         </p>
       </div>
@@ -56,6 +64,7 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
   const { data: rows, error, isPending: isRowsPending } = useInfiniteQuery(databaseRowsQuery({ database, table, schema, query: { filters, orderBy } }))
   const primaryColumns = useMemo(() => columns?.filter(c => c.primaryKey).map(c => c.id) ?? [], [columns])
   const { onOrder } = useHeaderActionsOrder()
+  const renameColumnRef = useRef<{ rename: (schema: string, table: string, column: string) => void }>(null)
 
   useEffect(() => {
     if (!rows || !store.state.selected)
@@ -196,6 +205,7 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
           <TableHeaderCell
             column={column}
             onSort={() => onOrder(column.id)}
+            onRename={() => renameColumnRef.current?.rename(schema, table, column.id)}
             {...props}
           />
         ),
@@ -235,7 +245,7 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
       estimatedRowSize={DEFAULT_ROW_HEIGHT}
       estimatedColumnSize={DEFAULT_COLUMN_WIDTH}
     >
-      <div className="size-full relative bg-background">
+      <div className="relative size-full bg-background">
         <Table>
           <TableHeader />
           {isRowsPending
@@ -260,6 +270,7 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
                     )}
         </Table>
       </div>
+      <RenameColumnDialog ref={renameColumnRef} database={database} />
     </TableProvider>
   )
 }

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
@@ -205,7 +205,9 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
           <TableHeaderCell
             column={column}
             onSort={() => onOrder(column.id)}
-            onRename={() => renameColumnRef.current?.rename(schema, table, column.id)}
+            onRename={database.type === 'clickhouse' && column.primaryKey
+              ? undefined
+              : () => renameColumnRef.current?.rename(schema, table, column.id)}
             {...props}
           />
         ),

--- a/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
+++ b/apps/desktop/src/routes/(protected)/_protected/database/$id/table/-components/table.tsx
@@ -205,7 +205,7 @@ function TableComponent({ table, schema }: { table: string, schema: string }) {
           <TableHeaderCell
             column={column}
             onSort={() => onOrder(column.id)}
-            onRename={database.type === 'clickhouse' && column.primaryKey
+            onRename={database.type === 'clickhouse' && column.primaryKey // Clickhouse doesn't support renaming primary keys
               ? undefined
               : () => renameColumnRef.current?.rename(schema, table, column.id)}
             {...props}

--- a/packages/shared/src/utils/helpers.ts
+++ b/packages/shared/src/utils/helpers.ts
@@ -53,6 +53,15 @@ export async function tryCatchAsync<T>(fn: () => Promise<T>): Promise<{ data: T,
   }
 }
 
+export function tryParseJson<T>(json: string): T | null {
+  try {
+    return JSON.parse(json) as T
+  }
+  catch {
+    return null
+  }
+}
+
 export function memoize<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F) {
   const cache = new Map<string, ReturnType<F>>()
 


### PR DESCRIPTION
## Description of Changes

- What was changed?
Added rename column option on a table
- Why was it changed?
Because users can now change column names inside the table
- Any related issues or discussions?

Closes #49 (If applicable, delete this line if not)

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- Are there any specific things the reviewer should focus on?
Here is the recording of it (Test in all 4 dbs)

https://github.com/user-attachments/assets/34c92b4b-c9f1-491b-80c0-7c29dda824f2


Have to write manual sql here for mssql because mssql uses sp_rename instead of normal rename and kysely doesnt have that 

so if we call renameColumn fuction it triggers rename and mssql command fails

```
    mssql: async (db) => {
      await sql`EXEC sp_rename ${sql.val(`${schema}.${table}.${oldColumn}`)}, ${sql.val(newColumn)}, 'COLUMN'`.execute(db)
    },
    clickhouse: db => db
      .withSchema(schema)
      .withTables<{ [table]: Record<string, unknown> }>()
      .schema
      .alterTable(table)
      .renameColumn(oldColumn, newColumn)
      .execute(),
  }),
```




cc: @letstri @geekyharsh05 
