### PR TITLE
fix: update docker commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "drizzle:migrate": "turbo run drizzle:migrate",
     "check-types": "turbo run check-types",
     "update": "taze -r -I major",
-    "docker:start": "docker-compose -f docker-compose.dev.yml up -d",
-    "docker:stop": "docker-compose -f docker-compose.dev.yml down"
+    "docker:start": "docker compose -f docker-compose.dev.yml up -d",
+    "docker:stop": "docker compose -f docker-compose.dev.yml down"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",


### PR DESCRIPTION
## Description of Changes

What was changed? 
- docker-compose to docker compose.

Why was it changed?
- because docker-compose is deprecated.

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally