### PR TITLE
fix: dark mode issue on web

### DIFF
--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,12 +1,19 @@
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Toaster as Sonner } from 'sonner'
 import { useTheme } from '../theme-observer'
 
 function Toaster() {
   const { resolvedTheme } = useTheme()
+  const [isMounted, setIsMounted] = useState(false)
 
-  if (typeof document === 'undefined')
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!isMounted) {
     return null
+  }
 
   return createPortal(
     <Sonner

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,15 +1,11 @@
-import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Toaster as Sonner } from 'sonner'
+import { useIsMounted } from '../hookas/use-is-mounted'
 import { useTheme } from '../theme-observer'
 
 function Toaster() {
   const { resolvedTheme } = useTheme()
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
+  const isMounted = useIsMounted()
 
   if (!isMounted) {
     return null


### PR DESCRIPTION
## Description of Changes

- What was changed?
1. Modified 
```packages/ui/src/components/sonner.tsx```
 to delay Toaster rendering until after component mount using useEffect

- Why was it changed?
1. Fixed ~2 second flash of light mode on initial page load

2. The Toaster component (using createPortal) was rendering before 
ThemeObserver could apply the dark class to the <html> element, causing the flash

3. Fixed Rules of Hooks violation by ensuring React hooks are called before conditional returns

- Any related issues or discussions?

Closes #270  (If applicable, delete this line if not)

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

https://github.com/user-attachments/assets/2c021076-8abe-4f47-81db-12ecb33b0684




- Are there any specific things the reviewer should focus on?

cc: @letstri @geekyharsh05 
