### PR TITLE
fix(web): styling and html structure of download button

### DIFF
--- a/apps/web/src/components/download-button.tsx
+++ b/apps/web/src/components/download-button.tsx
@@ -2,6 +2,7 @@ import type { OS } from '@conar/shared/utils/os'
 import { Button } from '@conar/ui/components/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@conar/ui/components/dropdown-menu'
 import { Linux } from '@conar/ui/components/icons/linux'
+import { cn } from '@conar/ui/lib/utils'
 import { RiAppleFill, RiWindowsFill } from '@remixicon/react'
 import { DOWNLOAD_LINKS } from '~/constants'
 import { getOSIsomorphic } from '~/utils/os'
@@ -14,10 +15,10 @@ const iconsMap: Partial<Record<OS, (props: { className?: string }) => React.Reac
   windows: ({ className }) => <RiWindowsFill className={className} />,
 }
 
-export function DownloadButton() {
+export function DownloadButton({ className }: { className?: string }) {
   if (!os) {
     return (
-      <Button disabled variant="secondary" size="lg">
+      <Button disabled variant="secondary" size="lg" className={className}>
         No downloads for your operating system :(
       </Button>
     )
@@ -34,7 +35,7 @@ export function DownloadButton() {
 
   if (assets.length === 1) {
     return (
-      <Button size="lg" className="flex items-center justify-center gap-2">
+      <Button size="lg" className={cn('flex items-center justify-center gap-2', className)} asChild>
         <a href={assets[0]!.link} download>
           {Icon && <Icon className="size-4" />}
           Download for
@@ -48,7 +49,7 @@ export function DownloadButton() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="lg" className="flex items-center justify-center gap-2">
+        <Button size="lg" className={cn('flex items-center justify-center gap-2', className)}>
           {Icon && <Icon className="size-4" />}
           Download for
           {' '}

--- a/apps/web/src/routes/_layout/-components/hero.tsx
+++ b/apps/web/src/routes/_layout/-components/hero.tsx
@@ -109,7 +109,7 @@ export function Hero({ className }: { className?: string }) {
             lg:w-auto
           `}
         >
-          <DownloadButton />
+          <DownloadButton className="w-full sm:w-auto" />
           <Button
             variant="secondary"
             asChild


### PR DESCRIPTION
## Description of Changes

### What was changed?

**Modified**
- `apps/web/download-button.tsx`
  - Updated `DownloadButton` to accept a `className` prop
  - Used `asChild` on the `Button` component so the `<a>` element receives button styles directly
  - Fixed invalid HTML caused by nesting an `<a>` tag inside a `<button>`

- `apps/web/hero.tsx`
  - Passed `className="w-full sm:w-auto"` to `DownloadButton`
  - Ensured consistent responsive styling with the “All platforms” button

---

### Why was it changed?

The **download button** in the hero section had visibility and styling issues.

- Invalid HTML structure (`<a>` inside `<button>`) can cause inconsistent styling and accessibility issues
- Missing responsive width classes made the button behave differently from its sibling buttons

These changes ensure:
- Valid HTML semantics
- Consistent responsive behavior
- Predictable styling across browsers

---

### Any related issues or discussions?

_None (first contribution)_

---

## Checklist

- [x] My changes are scoped and focused  
- [x] I have tested the code locally  
- [x] No breaking changes introduced  


---

## Notes to reviewer
![S1](https://github.com/user-attachments/assets/4453a494-683b-48c4-bf3c-e8079f9a24c3)

![S2](https://github.com/user-attachments/assets/e3917f09-c753-4b40-ac48-165e20b643cf)

- This is my **first PR** — happy to make changes if needed
- Happy to make any changes based on feedback.

---

### Are there any specific things the reviewer should focus on?

- HTML semantics after switching to `asChild`
- Styling consistency between hero section buttons

cc: @letstri @geekyharsh05 
