### PR TITLE
fix: web crash & dev error message

### DIFF
--- a/apps/web/src/components/download-button.tsx
+++ b/apps/web/src/components/download-button.tsx
@@ -16,15 +16,15 @@ const iconsMap: Partial<Record<OS, (props: { className?: string }) => React.Reac
 }
 
 export function DownloadButton({ className }: { className?: string }) {
-  if (!os) {
+  const links = os ? DOWNLOAD_LINKS[os.type as keyof typeof DOWNLOAD_LINKS] : null
+
+  if (!os || !links) {
     return (
       <Button disabled variant="secondary" size="lg" className={className}>
         No downloads for your operating system :(
       </Button>
     )
   }
-
-  const links = DOWNLOAD_LINKS[os.type as keyof typeof DOWNLOAD_LINKS]
 
   const Icon = iconsMap[os.type] || null
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -78,8 +78,8 @@ function RootComponent() {
       `)}
       >
         <QueryClientProvider client={queryClient}>
-          <Outlet />
           <ThemeObserver />
+          <Outlet />
           <ReactQueryDevtools buttonPosition="bottom-left" />
         </QueryClientProvider>
         <Toaster />


### PR DESCRIPTION
## Description of Changes

- What was changed?
1. Fixed a crash on the Download button: Added a check in 
DownloadButton to safely handle cases where the OS is detected (e.g., "unknown" or "android") but no download links are defined in ```DOWNLOAD_LINKS ```. This prevents the Object.entries(undefined) error that was occurring in production.

2. Fixed a React context initialization race condition: Moved the ``` <ThemeObserver /> ``` component above ```<Outlet />```  in  ```__root.tsx``` . This ensures the theme store is fully initialized before any child route components (like ThemeToggle) attempt to subscribe to it, resolving the "Cannot read properties of undefined (reading 'subscribe')" error during local development.

- Why was it changed?

1. To prevent production crashes when users visit the site from unsupported OSes.
2. To fix a persistent runtime error in the local development environment that blocked rendering.

- Any related issues or discussions?

Closes #287
Closes #288 

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- Are there any specific things the reviewer should focus on?
