### PR TITLE
refactor(ui): migrate scroll-area from Base UI to Radix UI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,6 @@
     "check-types": "tsgo"
   },
   "dependencies": {
-    "@base-ui/react": "catalog:",
     "@conar/configs": "workspace:*",
     "@conar/shared": "workspace:*",
     "@radix-ui/react-accordion": "catalog:",
@@ -29,6 +28,7 @@
     "@radix-ui/react-label": "catalog:",
     "@radix-ui/react-popover": "catalog:",
     "@radix-ui/react-progress": "catalog:",
+    "@radix-ui/react-scroll-area": "catalog:",
     "@radix-ui/react-select": "catalog:",
     "@radix-ui/react-separator": "catalog:",
     "@radix-ui/react-slot": "catalog:",

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,16 +1,23 @@
-import type { RefObject } from 'react'
-import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area'
 import { cn } from '@conar/ui/lib/utils'
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
+import * as React from 'react'
+
+type ScrollAreaProps
+  = ScrollAreaPrimitive.ScrollAreaProps & {
+    ref?: React.Ref<HTMLDivElement>
+  }
 
 function ScrollArea({
+  ref,
   className,
   children,
   ...props
-}: ScrollAreaPrimitive.Root.Props) {
+}: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
+      ref={ref}
       data-slot="scroll-area"
-      className={cn('group/scroll-area', className)}
+      className={cn('group/scroll-area overflow-hidden', className)}
       {...props}
     >
       {children}
@@ -19,17 +26,23 @@ function ScrollArea({
   )
 }
 
+type ScrollViewportProps
+  = ScrollAreaPrimitive.ScrollAreaViewportProps & {
+    ref?: React.Ref<HTMLDivElement>
+  }
+
 function ScrollViewport({
   ref,
   className,
   ...props
-}: ScrollAreaPrimitive.Viewport.Props & { ref?: RefObject<HTMLDivElement | null> }) {
+}: ScrollViewportProps) {
   return (
     <ScrollAreaPrimitive.Viewport
       ref={ref}
       data-slot="scroll-area-viewport"
       className={cn(
-        'focus-visible:ring-ring/50 size-full overscroll-contain transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1',
+        'size-full overscroll-contain transition-[color,box-shadow] outline-none',
+        'focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-1',
         className,
       )}
       {...props}
@@ -37,26 +50,39 @@ function ScrollViewport({
   )
 }
 
+type ScrollBarProps
+  = ScrollAreaPrimitive.ScrollAreaScrollbarProps & {
+    ref?: React.Ref<HTMLDivElement>
+  }
+
 function ScrollBar({
+  ref,
   className,
   orientation = 'vertical',
   ...props
-}: ScrollAreaPrimitive.Scrollbar.Props) {
+}: ScrollBarProps) {
   return (
     <ScrollAreaPrimitive.Scrollbar
+      ref={ref}
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
         'flex touch-none p-px transition-[colors,width,height] select-none',
-        orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
-        orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
+        orientation === 'vertical'
+        && 'h-full w-2.5 border-l border-l-transparent',
+        orientation === 'horizontal'
+        && 'h-2.5 flex-col border-t border-t-transparent',
         className,
       )}
       {...props}
     >
       <ScrollAreaPrimitive.Thumb
         data-slot="scroll-area-thumb"
-        className="z-20 duration-150 transition-colors bg-transparent group-hover/scroll-area:bg-accent/60 relative flex-1 rounded-full"
+        className={`
+          relative z-20 flex-1 rounded-full bg-transparent transition-colors
+          duration-150
+          group-hover/scroll-area:bg-accent/60
+        `}
       />
     </ScrollAreaPrimitive.Scrollbar>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     '@radix-ui/react-progress':
       specifier: ^1.1.8
       version: 1.1.8
+    '@radix-ui/react-scroll-area':
+      specifier: ^1.2.0
+      version: 1.2.10
     '@radix-ui/react-select':
       specifier: ^2.2.6
       version: 2.2.6
@@ -1145,6 +1148,9 @@ importers:
       '@radix-ui/react-progress':
         specifier: 'catalog:'
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-scroll-area':
+        specifier: 'catalog:'
+        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-select':
         specifier: 'catalog:'
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3751,6 +3757,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -13425,6 +13444,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,6 @@ catalog:
   '@ai-sdk/react': ^3.0.7
   '@ai-sdk/xai': ^3.0.3
   '@antfu/eslint-config': ^6.7.3
-  '@base-ui/react': ^1.0.0
   '@clickhouse/client': ^1.16.0
   '@commitlint/cli': ^20.3.0
   '@commitlint/config-conventional': ^20.3.0
@@ -46,6 +45,7 @@ catalog:
   '@radix-ui/react-label': ^2.1.8
   '@radix-ui/react-popover': ^1.1.15
   '@radix-ui/react-progress': ^1.1.8
+  '@radix-ui/react-scroll-area': ^1.2.0
   '@radix-ui/react-select': ^2.2.6
   '@radix-ui/react-separator': ^1.1.8
   '@radix-ui/react-slot': ^1.2.4


### PR DESCRIPTION
- Replace @base-ui/react with @radix-ui/react-scroll-area
- Update ScrollArea component to use Radix UI primitives
- Improve type definitions with proper React ref types
- Update className ordering and formatting
- Remove unused @base-ui/react from catalog