### PR TITLE
feat(databases-list): add remove from recent button

### DIFF
--- a/apps/desktop/src/routes/_protected/-components/connections-list.tsx
+++ b/apps/desktop/src/routes/_protected/-components/connections-list.tsx
@@ -4,6 +4,7 @@ import { SafeURL } from '@conar/shared/utils/safe-url'
 import { Badge } from '@conar/ui/components/badge'
 import { Button } from '@conar/ui/components/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@conar/ui/components/dropdown-menu'
+import { Separator } from '@conar/ui/components/separator'
 import { Tabs, TabsList, TabsTrigger } from '@conar/ui/components/tabs'
 import { copy } from '@conar/ui/lib/copy'
 import { cn } from '@conar/ui/lib/utils'
@@ -47,13 +48,17 @@ function ConnectionCard({
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.75 }}
       transition={{ duration: 0.15 }}
-      className="relative"
+      className="group relative"
     >
       {onClose && (
         <Button
           variant="outline"
           size="icon-xs"
-          className="absolute -top-1.5 -right-1.5 z-10 rounded-full bg-card!"
+          className="
+            absolute -top-1.5 -right-1.5 z-10 rounded-full bg-card! opacity-0
+            duration-75
+            group-hover:opacity-100
+          "
           onClick={() => onClose()}
         >
           <RiCloseLine className="size-3.5" />
@@ -217,7 +222,7 @@ function LastOpenedConnections({
   )
 }
 
-export function DatabasesList() {
+export function ConnectionsList() {
   const { data: connections } = useLiveQuery(q => q
     .from({ connections: connectionsCollection })
     .orderBy(({ connections }) => connections.createdAt, 'desc'))
@@ -252,7 +257,7 @@ export function DatabasesList() {
         />
       )}
       {hasLastOpened && (
-        <div className="border-t border-border/50" />
+        <Separator />
       )}
       {availableLabels.length > 0 && (
         <Tabs

--- a/apps/desktop/src/routes/_protected/-components/databases-list.tsx
+++ b/apps/desktop/src/routes/_protected/-components/databases-list.tsx
@@ -63,7 +63,7 @@ function ConnectionCard({
         className={cn(
           `
             group relative flex items-center justify-between gap-4
-            overflow-visible rounded-lg border border-l-4 border-border/50
+            overflow-hidden rounded-lg border border-l-4 border-border/50
             bg-muted/30 p-5
           `,
           connection.color

--- a/apps/desktop/src/routes/_protected/-components/databases-list.tsx
+++ b/apps/desktop/src/routes/_protected/-components/databases-list.tsx
@@ -55,7 +55,6 @@ function ConnectionCard({
           size="icon-xs"
           className="absolute -top-1.5 -right-1.5 z-10 rounded-full bg-card!"
           onClick={() => onClose()}
-          aria-label="Remove from recent"
         >
           <RiCloseLine className="size-3.5" />
         </Button>

--- a/apps/desktop/src/routes/_protected/-components/databases-list.tsx
+++ b/apps/desktop/src/routes/_protected/-components/databases-list.tsx
@@ -49,7 +49,7 @@ function ConnectionCard({ connection, onRemove, onRename, onRemoveFromRecent }: 
         className={cn(
           `
             group relative flex items-center justify-between gap-4
-            overflow-hidden rounded-lg border border-l-4 border-border/50
+            overflow-visible rounded-lg border border-l-4 border-border/50
             bg-muted/30 p-5
           `,
           connection.color
@@ -63,6 +63,30 @@ function ConnectionCard({ connection, onRemove, onRename, onRemoveFromRecent }: 
         preload={false}
         {...params}
       >
+        {onRemoveFromRecent && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="
+              absolute -top-1.5 -right-1.5 z-10 rounded-full
+              bg-muted/80 backdrop-blur-sm shadow-sm
+              opacity-0 scale-90 transition-all duration-200 ease-out
+              group-hover:opacity-100 group-hover:scale-100
+              hover:bg-muted hover:shadow-md hover:scale-105
+              active:scale-95 active:shadow-sm
+              focus-visible:opacity-100 focus-visible:scale-100
+              focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1
+            "
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onRemoveFromRecent?.()
+            }}
+            aria-label="Remove from recent"
+          >
+            <RiCloseLine className="size-3.5 transition-transform duration-150 group-hover:rotate-90" />
+          </Button>
+        )}
         <div className="size-12 shrink-0 rounded-lg bg-muted/70 p-3">
           <ConnectionIcon
             type={connection.type}
@@ -96,64 +120,48 @@ function ConnectionCard({ connection, onRemove, onRename, onRemoveFromRecent }: 
             {connectionString.replaceAll('*', '•')}
           </div>
         </div>
-        <div className="flex items-center gap-1">
-          {onRemoveFromRecent && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="opacity-0 transition-opacity group-hover:opacity-100"
+        <DropdownMenu>
+          <DropdownMenuTrigger className={`
+            rounded-md p-2
+            hover:bg-accent-foreground/5
+          `}
+          >
+            <RiMoreLine className="size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
               onClick={(e) => {
-                e.preventDefault()
                 e.stopPropagation()
-                onRemoveFromRecent?.()
+                copy(connection.connectionString, 'Connection string copied to clipboard')
               }}
             >
-              <RiCloseLine className="size-4" />
-            </Button>
-          )}
-          <DropdownMenu>
-            <DropdownMenuTrigger className={`
-              rounded-md p-2
-              hover:bg-accent-foreground/5
-            `}
+              <RiFileCopyLine className="size-4 opacity-50" />
+              Copy Connection String
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                onRename()
+              }}
             >
-              <RiMoreLine className="size-4" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation()
-                  copy(connection.connectionString, 'Connection string copied to clipboard')
-                }}
-              >
-                <RiFileCopyLine className="size-4 opacity-50" />
-                Copy Connection String
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onRename()
-                }}
-              >
-                <RiEditLine className="size-4 opacity-50" />
-                Rename
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className={`
-                  text-destructive
-                  focus:text-destructive
-                `}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onRemove()
-                }}
-              >
-                <RiDeleteBinLine className="size-4" />
-                Remove
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+              <RiEditLine className="size-4 opacity-50" />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={`
+                text-destructive
+                focus:text-destructive
+              `}
+              onClick={(e) => {
+                e.stopPropagation()
+                onRemove()
+              }}
+            >
+              <RiDeleteBinLine className="size-4" />
+              Remove
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </Link>
     </motion.div>
   )

--- a/apps/desktop/src/routes/_protected/index.tsx
+++ b/apps/desktop/src/routes/_protected/index.tsx
@@ -11,7 +11,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { useConnectionsSync } from '~/entities/connection/sync'
 import { checkForUpdates, updatesStore } from '~/use-updates-observer'
-import { DatabasesList } from './-components/databases-list'
+import { ConnectionsList } from './-components/connections-list'
 import { Profile } from './-components/profile'
 
 export const Route = createFileRoute('/_protected/')({
@@ -70,7 +70,7 @@ function DashboardPage() {
             </Button>
           </div>
         </div>
-        <DatabasesList />
+        <ConnectionsList />
         <div className="mt-auto py-6">
           <Separator />
           <div className="mt-3 flex items-center gap-2">


### PR DESCRIPTION
## Description of Changes

- **What was changed?**
  - Added a close button (X icon) to remove items from the "Recently Opened" list
  - Button appears on hover to the left of the actions menu (three dots)
  - Uses the shared `Button` component with `variant="ghost"` and `size="icon-sm"`

- **Why was it changed?**
  - Previously, there was no way to remove databases from the Recently Opened list
  - Entries remained even if the database was deleted, renamed, or inaccessible

- **Any related issues or discussions?**
  - Solves the problem of removing items from the Recently Opened list

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

Closes #315 