### PR TITLE
feat(runner): add execution time tracking to query results

### DIFF
--- a/apps/desktop/src/routes/_protected/database/$id/sql/-components/runner/runner-results-table.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/sql/-components/runner/runner-results-table.tsx
@@ -17,9 +17,11 @@ import { DEFAULT_COLUMN_WIDTH } from '~/entities/connection/components/table/uti
 export function RunnerResultsTable({
   data,
   columns,
+  executionTime,
 }: {
   data: Record<string, unknown>[]
   columns: Column[]
+  executionTime: number
 }) {
   const [search, setSearch] = useState('')
 
@@ -63,6 +65,16 @@ export function RunnerResultsTable({
     return limit ? filteredData.slice(0, limit) : filteredData
   }
 
+  const formatExecutionTime = (ms: number) => {
+    if (ms < 1) {
+      return `${(ms * 1000).toFixed(0)}μs`
+    }
+    if (ms < 1000) {
+      return `${ms.toFixed(2)}ms`
+    }
+    return `${(ms / 1000).toFixed(2)}s`
+  }
+
   return (
     <div className="h-full">
       <div className="flex h-10 items-center justify-between gap-2 pr-1 pl-4">
@@ -73,6 +85,10 @@ export function RunnerResultsTable({
             {' '}
             {filteredData.length === 1 ? 'row' : 'rows'}
             {search && filteredData.length !== data.length && ` (filtered from ${data.length})`}
+          </span>
+          <Separator orientation="vertical" className="h-4!" />
+          <span className="text-xs text-muted-foreground">
+            {formatExecutionTime(executionTime)}
           </span>
         </div>
         <div className="flex items-center gap-2">

--- a/apps/desktop/src/routes/_protected/database/$id/sql/-components/runner/runner-results.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/sql/-components/runner/runner-results.tsx
@@ -82,7 +82,7 @@ export function RunnerResults() {
             </TabsTrigger>
           ))}
         </TabsList>
-        {results.map(({ data, error, startLineNumber, endLineNumber }, index) => (
+        {results.map(({ data, error, startLineNumber, endLineNumber, executionTime }, index) => (
           <TabsContent
             // eslint-disable-next-line react/no-array-index-key
             key={index}
@@ -155,6 +155,7 @@ export function RunnerResults() {
                       <RunnerResultsTable
                         data={data}
                         columns={Object.keys(data[0]!).map(key => ({ id: key }))}
+                        executionTime={executionTime}
                       />
                     )}
           </TabsContent>


### PR DESCRIPTION
## Description of Changes

What was changed?
- Add execution time tracking for query.

Why was it changed?
- User should be able to see the time taken to execute a query.

## Screenshots

<img width="576" height="146" alt="image" src="https://github.com/user-attachments/assets/ad740edc-7c47-471c-85ac-e76e46439c41" />

<br />

<img width="1676" height="400" alt="image" src="https://github.com/user-attachments/assets/b8d52441-702c-4952-97a5-d131ec7d6284" />


Closes #319

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

