### PR TITLE
feat(visualizer): add table search and highlight matches

### DIFF
--- a/apps/desktop/src/entities/connection/components/react-flow-node.tsx
+++ b/apps/desktop/src/entities/connection/components/react-flow-node.tsx
@@ -12,6 +12,8 @@ export type NodeType = Node<{
   table: string
   columns: Column[]
   selected?: boolean
+  searchActive?: boolean
+  searchMatched?: boolean
   edges: Edge[]
 }, 'tableNode'>
 
@@ -22,8 +24,11 @@ export function ReactFlowNode({ data }: NodeProps<NodeType>) {
         `
           w-66 rounded-xl bg-card font-mono
           shadow-[0_1px_1px_rgba(0,0,0,0.02),0_2px_2px_rgba(0,0,0,0.02),0_4px_4px_rgba(0,0,0,0.02),0_8px_8px_rgba(0,0,0,0.02),0_16px_16px_rgba(0,0,0,0.02),0_32px_32px_rgba(0,0,0,0.02)]
+          transition-opacity
         `,
-        data.selected ? 'ring-2 ring-primary ring-offset-2' : '',
+        data.selected && 'ring-2 ring-primary ring-offset-2',
+        !data.selected && data.searchActive && data.searchMatched && 'ring-2 ring-primary/60 ring-offset-2',
+        data.searchActive && !data.searchMatched && !data.selected && 'opacity-50',
       )}
     >
       <div className="

--- a/apps/desktop/src/routes/_protected/database/$id/visualizer/-lib.test.ts
+++ b/apps/desktop/src/routes/_protected/database/$id/visualizer/-lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test'
+import { applySearchHighlight, getTableSearchState } from './-lib'
+
+function createNode(table: string) {
+  return {
+    id: table,
+    type: 'tableNode',
+    position: { x: 0, y: 0 },
+    data: {
+      databaseId: 'db',
+      schema: 'public',
+      table,
+      columns: [],
+      edges: [],
+    },
+  }
+}
+
+describe('getTableSearchState', () => {
+  it('returns an inactive state for an empty query', () => {
+    const result = getTableSearchState({ tables: ['users', 'posts'], query: '   ' })
+
+    expect(result.isActive).toBe(false)
+    expect([...result.matchedTables]).toEqual([])
+  })
+
+  it('matches tables case-insensitively', () => {
+    const result = getTableSearchState({ tables: ['users', 'user_logs', 'posts'], query: 'UsEr' })
+
+    expect(result.isActive).toBe(true)
+    expect([...result.matchedTables].sort()).toEqual(['user_logs', 'users'])
+  })
+
+  it('keeps search active even when no table matches', () => {
+    const result = getTableSearchState({ tables: ['users', 'posts'], query: 'orders' })
+
+    expect(result.isActive).toBe(true)
+    expect([...result.matchedTables]).toEqual([])
+  })
+})
+
+describe('applySearchHighlight', () => {
+  it('flags matched and unmatched nodes when search is active', () => {
+    const nodes = [createNode('users'), createNode('posts')]
+    const highlighted = applySearchHighlight({
+      nodes: nodes as Parameters<typeof applySearchHighlight>[0]['nodes'],
+      isSearchActive: true,
+      matchedTables: new Set(['users']),
+    })
+
+    expect(highlighted[0]?.data.searchActive).toBe(true)
+    expect(highlighted[0]?.data.searchMatched).toBe(true)
+    expect(highlighted[1]?.data.searchActive).toBe(true)
+    expect(highlighted[1]?.data.searchMatched).toBe(false)
+  })
+
+  it('resets highlight flags when search is inactive', () => {
+    const nodes = [createNode('users'), createNode('posts')]
+    const highlighted = applySearchHighlight({
+      nodes: nodes as Parameters<typeof applySearchHighlight>[0]['nodes'],
+      isSearchActive: false,
+      matchedTables: new Set(['users']),
+    })
+
+    expect(highlighted[0]?.data.searchActive).toBe(false)
+    expect(highlighted[0]?.data.searchMatched).toBe(false)
+    expect(highlighted[1]?.data.searchActive).toBe(false)
+    expect(highlighted[1]?.data.searchMatched).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description of Changes

**What was changed?**
- Added table search to the database visualizer UI.
- Added keyboard shortcut support (`Ctrl+F` / `Cmd+F`) to focus/select the visualizer search input.
- Implemented highlight behavior for search results:
  - matched tables are highlighted
  - unmatched tables are dimmed
  - no table hiding
- Refactored visualizer logic into reusable helpers (`getTableSearchState`, `applySearchHighlight`, `getVisualizerLayout`).
- Added unit tests for visualizer search/highlight helper logic.
- Reduced search input width for a better fit in the visualizer header.

 **Why was it changed?**
- To speed up table discovery in large schemas.
- To support keyboard-first navigation and reduce mouse interaction.
- To keep the code maintainable and testable.
- Any related issues or discussions?

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- Please focus on visualizer shortcut behavior (`Ctrl/Cmd + F`) and confirm no UX conflict.
- Please validate highlight rendering (matched ring + unmatched dimming), including behavior when switching schema.
- Please review helper extraction + unit tests for search/highlight logic.

## Screenshot
<img width="1505" height="497" alt="image" src="https://github.com/user-attachments/assets/cd03777c-4e82-462c-aba1-785b75a931b6" />
<img width="1413" height="733" alt="image" src="https://github.com/user-attachments/assets/2714aa09-3af8-4bea-81df-6dca7b26d78b" />
