### PR TITLE
fix: overflow for schema select on visualizer and definitions

### DIFF
--- a/apps/desktop/src/routes/_protected/database/$id/definitions/constraints/index.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/definitions/constraints/index.tsx
@@ -111,10 +111,10 @@ function DatabaseConstraintsPage() {
         </Select>
         {schemas.length > 1 && (
           <Select value={selectedSchema ?? ''} onValueChange={setSelectedSchema}>
-            <SelectTrigger className="w-[180px]">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">schema</span>
-                <SelectValue />
+            <SelectTrigger className="min-w-[180px] max-w-56">
+              <div className="flex flex-1 items-center gap-2 overflow-hidden">
+                <span className="text-muted-foreground shrink-0">schema</span>
+                <span className="truncate"><SelectValue /></span>
               </div>
             </SelectTrigger>
             <SelectContent>

--- a/apps/desktop/src/routes/_protected/database/$id/definitions/enums/index.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/definitions/enums/index.tsx
@@ -74,10 +74,10 @@ function DatabaseEnumsPage() {
         />
         {schemas.length > 1 && (
           <Select value={selectedSchema ?? ''} onValueChange={setSelectedSchema}>
-            <SelectTrigger className="w-[180px]">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">schema</span>
-                <SelectValue />
+            <SelectTrigger className="min-w-[180px] max-w-56">
+              <div className="flex flex-1 items-center gap-2 overflow-hidden">
+                <span className="text-muted-foreground shrink-0">schema</span>
+                <span className="truncate"><SelectValue /></span>
               </div>
             </SelectTrigger>
             <SelectContent>

--- a/apps/desktop/src/routes/_protected/database/$id/definitions/indexes/index.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/definitions/indexes/index.tsx
@@ -137,10 +137,10 @@ function DatabaseIndexesPage() {
         </Select>
         {schemas.length > 1 && (
           <Select value={selectedSchema ?? ''} onValueChange={setSelectedSchema}>
-            <SelectTrigger className="w-[180px]">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">schema</span>
-                <SelectValue />
+            <SelectTrigger className="min-w-[180px] max-w-56">
+              <div className="flex flex-1 items-center gap-2 overflow-hidden">
+                <span className="text-muted-foreground shrink-0">schema</span>
+                <span className="truncate"><SelectValue /></span>
               </div>
             </SelectTrigger>
             <SelectContent>

--- a/apps/desktop/src/routes/_protected/database/$id/visualizer/index.tsx
+++ b/apps/desktop/src/routes/_protected/database/$id/visualizer/index.tsx
@@ -229,12 +229,12 @@ function Visualizer({
             setSearchQuery('')
           }}
         >
-          <SelectTrigger>
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">
+          <SelectTrigger className="min-w-[180px] max-w-56">
+            <div className="flex flex-1 items-center gap-2 overflow-hidden text-left">
+              <span className="text-muted-foreground shrink-0">
                 schema
               </span>
-              <SelectValue placeholder="Select schema" />
+              <span className="truncate"><SelectValue placeholder="Select schema" /></span>
             </div>
           </SelectTrigger>
           <SelectContent>


### PR DESCRIPTION
## Description of Changes

- What was changed?
added truncate and a fixed size to schema select tag on visualizer and definitions page
- Why was it changed?
It was causing an overflow on long schema names
- Any related issues or discussions?

Closes #369 (If applicable, delete this line if not)

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- Are there any specific things the reviewer should focus on?
<img width="563" height="176" alt="Screenshot 2026-02-26 at 7 52 27 PM" src="https://github.com/user-attachments/assets/cfa8c1cc-4ebb-48f8-8725-333dade5a03b" />


