### PR TITLE
feat: add views support for all database dialects

### DIFF
--- a/apps/desktop/src/entities/connection/queries/tables-and-schemas.ts
+++ b/apps/desktop/src/entities/connection/queries/tables-and-schemas.ts
@@ -15,77 +15,131 @@ export const connectionSystemNames = {
 export const tablesAndSchemasType = type({
   schema: 'string',
   table: 'string',
+  table_type: 'string',
 })
 
-export const resourceTablesAndSchemasQuery = memoize(({ silent, connectionResource, showSystem }: { silent: boolean, connectionResource: typeof connectionsResources.$inferSelect, showSystem: boolean }) => {
-  const query = createQuery({
-    type: tablesAndSchemasType.array(),
+export const resourceTablesAndSchemasQuery = memoize(
+  ({
     silent,
-    query: {
-      postgres: db => db
-        .selectFrom('information_schema.tables')
-        .select([
-          'table_schema as schema',
-          'table_name as table',
-        ])
-        .where(({ eb, and, not }) => and([
-          not(eb('table_schema', 'like', 'pg_toast%')),
-          not(eb('table_schema', 'like', 'pg_temp%')),
-          eb('table_type', '=', 'BASE TABLE'),
-        ]))
-        .$if(!showSystem, qb => qb.where(({ eb, and }) => and([
-          eb('table_schema', 'not in', ['pg_catalog', 'information_schema']),
-        ])))
-        .execute(),
-      mysql: db => db
-        .selectFrom('information_schema.TABLES')
-        .select([
-          'TABLE_SCHEMA as schema',
-          'TABLE_NAME as table',
-        ])
-        .where('TABLE_TYPE', '=', 'BASE TABLE')
-        .$if(!showSystem, qb => qb.where(eb => eb('TABLE_SCHEMA', 'not in', ['mysql', 'information_schema', 'performance_schema', 'sys'])))
-        .execute(),
-      mssql: db => db
-        .selectFrom('information_schema.TABLES')
-        .select([
-          'TABLE_SCHEMA as schema',
-          'TABLE_NAME as table',
-        ])
-        .where('TABLE_TYPE', '=', 'BASE TABLE')
-        .execute(),
-      clickhouse: db => db
-        .selectFrom('information_schema.tables')
-        .select([
-          'table_schema as schema',
-          'table_name as table',
-        ])
-        .where('table_type', '=', 'BASE TABLE')
-        .where('table_schema', '=', connectionResource.name || connectionSystemNames.clickhouse)
-        .execute(),
-    },
-  })
+    connectionResource,
+    showSystem,
+  }: {
+    silent: boolean
+    connectionResource: typeof connectionsResources.$inferSelect
+    showSystem: boolean
+  }) => {
+    const query = createQuery({
+      type: tablesAndSchemasType.array(),
+      silent,
+      query: {
+        postgres: db =>
+          db
+            .selectFrom('information_schema.tables')
+            .select([
+              'table_schema as schema',
+              'table_name as table',
+              'table_type',
+            ])
+            .where(({ eb, and, not }) =>
+              and([
+                not(eb('table_schema', 'like', 'pg_toast%')),
+                not(eb('table_schema', 'like', 'pg_temp%')),
+                eb('table_type', 'in', ['BASE TABLE', 'VIEW']),
+              ]),
+            )
+            .$if(!showSystem, qb =>
+              qb.where(({ eb, and }) =>
+                and([
+                  eb('table_schema', 'not in', [
+                    'pg_catalog',
+                    'information_schema',
+                  ]),
+                ]),
+              ))
+            .execute(),
+        mysql: db =>
+          db
+            .selectFrom('information_schema.TABLES')
+            .select([
+              'TABLE_SCHEMA as schema',
+              'TABLE_NAME as table',
+              'TABLE_TYPE as table_type',
+            ])
+            .where('TABLE_TYPE', 'in', ['BASE TABLE', 'VIEW'])
+            .$if(!showSystem, qb =>
+              qb.where(eb =>
+                eb('TABLE_SCHEMA', 'not in', [
+                  'mysql',
+                  'information_schema',
+                  'performance_schema',
+                  'sys',
+                ]),
+              ))
+            .execute(),
+        mssql: db =>
+          db
+            .selectFrom('information_schema.TABLES')
+            .select([
+              'TABLE_SCHEMA as schema',
+              'TABLE_NAME as table',
+              'TABLE_TYPE as table_type',
+            ])
+            .where('TABLE_TYPE', 'in', ['BASE TABLE', 'VIEW'])
+            .execute(),
+        clickhouse: db =>
+          db
+            .selectFrom('information_schema.tables')
+            .select([
+              'table_schema as schema',
+              'table_name as table',
+              'table_type',
+            ])
+            .where('table_type', 'in', ['BASE TABLE', 'VIEW'])
+            .where(
+              'table_schema',
+              '=',
+              connectionResource.name || connectionSystemNames.clickhouse,
+            )
+            .execute(),
+      },
+    })
 
-  return queryOptions({
-    queryKey: ['connection-resource', connectionResource.id, 'tables-and-schemas', showSystem],
-    queryFn: async () => {
-      const results = await query.run(connectionResourceToQueryParams(connectionResource))
-      const schemas = Object.entries(Object.groupBy(results, table => table.schema)).map(([schema, tables]) => ({
-        name: schema,
-        tables: tables!.map(table => table.table),
-      }))
+    return queryOptions({
+      queryKey: [
+        'connection-resource',
+        connectionResource.id,
+        'tables-and-schemas',
+        showSystem,
+      ],
+      queryFn: async () => {
+        const results = await query.run(
+          connectionResourceToQueryParams(connectionResource),
+        )
+        const schemas = Object.entries(
+          Object.groupBy(results, table => table.schema),
+        ).map(([schema, tables]) => ({
+          name: schema,
+          tables: tables!.map(table => ({
+            name: table.table,
+            isView: table.table_type === 'VIEW',
+          })),
+        }))
 
-      return {
-        totalSchemas: schemas.length,
-        totalTables: schemas.reduce((acc, schema) => acc + schema.tables.length, 0),
-        schemas: schemas.toSorted((a, b) => {
-          if (a.name === 'public' && b.name !== 'public')
-            return -1
-          if (b.name === 'public' && a.name !== 'public')
-            return 1
-          return a.name.localeCompare(b.name)
-        }),
-      }
-    },
-  })
-})
+        return {
+          totalSchemas: schemas.length,
+          totalTables: schemas.reduce(
+            (acc, schema) => acc + schema.tables.length,
+            0,
+          ),
+          schemas: schemas.toSorted((a, b) => {
+            if (a.name === 'public' && b.name !== 'public')
+              return -1
+            if (b.name === 'public' && a.name !== 'public')
+              return 1
+            return a.name.localeCompare(b.name)
+          }),
+        }
+      },
+    })
+  },
+)

--- a/apps/desktop/src/entities/connection/utils/monaco.ts
+++ b/apps/desktop/src/entities/connection/utils/monaco.ts
@@ -38,9 +38,17 @@ const keywordPriority = [
 
 const dotMatchesRegex = /(\w+(?:\.\w+)*)\.\s*$/g
 
-export function connectionCompletionService(connectionResource: typeof connectionsResources.$inferSelect): CompletionService {
+export function connectionCompletionService(
+  connectionResource: typeof connectionsResources.$inferSelect,
+): CompletionService {
   const store = getConnectionResourceStore(connectionResource.id)
-  queryClient.prefetchQuery(resourceTablesAndSchemasQuery({ silent: false, connectionResource, showSystem: store.get().showSystem }))
+  queryClient.prefetchQuery(
+    resourceTablesAndSchemasQuery({
+      silent: false,
+      connectionResource,
+      showSystem: store.get().showSystem,
+    }),
+  )
   queryClient.prefetchQuery(resourceEnumsQuery({ connectionResource }))
 
   return async (
@@ -68,7 +76,13 @@ export function connectionCompletionService(connectionResource: typeof connectio
     })
 
     const [tablesAndSchemas, enums] = await Promise.all([
-      queryClient.ensureQueryData(resourceTablesAndSchemasQuery({ silent: false, connectionResource, showSystem: store.get().showSystem })),
+      queryClient.ensureQueryData(
+        resourceTablesAndSchemasQuery({
+          silent: false,
+          connectionResource,
+          showSystem: store.get().showSystem,
+        }),
+      ),
       queryClient.ensureQueryData(resourceEnumsQuery({ connectionResource })),
     ])
 
@@ -82,8 +96,12 @@ export function connectionCompletionService(connectionResource: typeof connectio
     })
 
     const dotMatches = [...textBeforeCursor.matchAll(dotMatchesRegex)]
-    const isTableContext = syntax.some(item => item.syntaxContextType === EntityContextType.TABLE)
-    const isColumnContext = syntax.some(item => item.syntaxContextType === EntityContextType.COLUMN)
+    const isTableContext = syntax.some(
+      item => item.syntaxContextType === EntityContextType.TABLE,
+    )
+    const isColumnContext = syntax.some(
+      item => item.syntaxContextType === EntityContextType.COLUMN,
+    )
 
     if (dotMatches.length > 0) {
       const tableRef = dotMatches.at(-1)?.[1]
@@ -93,20 +111,29 @@ export function connectionCompletionService(connectionResource: typeof connectio
         const schemaName = parts.length === 2 ? parts[0]! : 'public'
         const tableName = parts.length === 2 ? parts[1]! : parts[0]!
 
-        const schema = tablesAndSchemas?.schemas.find(s => s.name === schemaName)
-        const table = schema?.tables.find(t => t === tableName)
+        const schema = tablesAndSchemas?.schemas.find(
+          s => s.name === schemaName,
+        )
+        const table = schema?.tables.find(t => t.name === tableName)
 
         if (table) {
           const columns = await queryClient.ensureQueryData(
-            resourceTableColumnsQuery({ connectionResource, schema: schemaName, table: tableName }),
+            resourceTableColumnsQuery({
+              connectionResource,
+              schema: schemaName,
+              table: tableName,
+            }),
           )
-          const columnItems = columns.map(col => ({
-            label: col.id,
-            kind: languages.CompletionItemKind.Field,
-            detail: `${col.type}${col.isNullable ? ' (nullable)' : ' (not null)'}`,
-            sortText: `1${col.id}`,
-            insertText: col.id,
-          } satisfies ICompletionItem))
+          const columnItems = columns.map(
+            col =>
+              ({
+                label: col.id,
+                kind: languages.CompletionItemKind.Field,
+                detail: `${col.type}${col.isNullable ? ' (nullable)' : ' (not null)'}`,
+                sortText: `1${col.id}`,
+                insertText: col.id,
+              }) satisfies ICompletionItem,
+          )
           return [...columnItems, ...keywordItems]
         }
       }
@@ -115,42 +142,56 @@ export function connectionCompletionService(connectionResource: typeof connectio
 
     if (tablesAndSchemas && isColumnContext && !isTableContext) {
       const columnPromises = tablesAndSchemas.schemas.flatMap(schema =>
-        schema.tables.map(async (tableName) => {
+        schema.tables.map(async (tableEntry) => {
           const columns = await queryClient.ensureQueryData(
-            resourceTableColumnsQuery({ connectionResource, schema: schema.name, table: tableName }),
+            resourceTableColumnsQuery({
+              connectionResource,
+              schema: schema.name,
+              table: tableEntry.name,
+            }),
           )
-          return columns.map(col => ({
-            label: col.id,
-            kind: languages.CompletionItemKind.Field,
-            detail: `${col.type}${col.isNullable ? ' (nullable)' : ' (not null)'}`,
-            sortText: `1${col.id}`,
-            insertText: col.id,
-          } satisfies ICompletionItem))
+          return columns.map(
+            col =>
+              ({
+                label: col.id,
+                kind: languages.CompletionItemKind.Field,
+                detail: `${col.type}${col.isNullable ? ' (nullable)' : ' (not null)'}`,
+                sortText: `1${col.id}`,
+                insertText: col.id,
+              }) satisfies ICompletionItem,
+          )
         }),
       )
       const allColumns = (await Promise.all(columnPromises)).flat()
 
-      items.push(...allColumns.filter((item, i, arr) => arr.findIndex(x => x.label === item.label) === i))
+      items.push(
+        ...allColumns.filter(
+          (item, i, arr) => arr.findIndex(x => x.label === item.label) === i,
+        ),
+      )
     }
 
     if (tablesAndSchemas) {
       const tableItems = tablesAndSchemas.schemas.flatMap(schema =>
-        schema.tables.flatMap(tableName => [
-          {
-            label: tableName,
-            kind: languages.CompletionItemKind.Class,
-            detail: `table (${schema.name})`,
-            sortText: `2${tableName}`,
-            insertText: tableName,
-          } satisfies ICompletionItem,
-          {
-            label: `${schema.name}.${tableName}`,
-            kind: languages.CompletionItemKind.Class,
-            detail: `table (${schema.name})`,
-            sortText: `2${schema.name}.${tableName}`,
-            insertText: `${schema.name}.${tableName}`,
-          } satisfies ICompletionItem,
-        ]),
+        schema.tables.flatMap((tableEntry) => {
+          const kind = tableEntry.isView ? 'view' : 'table'
+          return [
+            {
+              label: tableEntry.name,
+              kind: languages.CompletionItemKind.Class,
+              detail: `${kind} (${schema.name})`,
+              sortText: `2${tableEntry.name}`,
+              insertText: tableEntry.name,
+            } satisfies ICompletionItem,
+            {
+              label: `${schema.name}.${tableEntry.name}`,
+              kind: languages.CompletionItemKind.Class,
+              detail: `${kind} (${schema.name})`,
+              sortText: `2${schema.name}.${tableEntry.name}`,
+              insertText: `${schema.name}.${tableEntry.name}`,
+            } satisfies ICompletionItem,
+          ]
+        }),
       )
 
       items.push(...tableItems)
@@ -158,13 +199,16 @@ export function connectionCompletionService(connectionResource: typeof connectio
 
     if (enums) {
       const enumItems = enums.flatMap(enumItem =>
-        enumItem.values.map(value => ({
-          label: value,
-          kind: languages.CompletionItemKind.EnumMember,
-          detail: `enum value (${enumItem.schema}.${enumItem.name})`,
-          sortText: `3${value}`,
-          insertText: value,
-        } satisfies ICompletionItem)),
+        enumItem.values.map(
+          value =>
+            ({
+              label: value,
+              kind: languages.CompletionItemKind.EnumMember,
+              detail: `enum value (${enumItem.schema}.${enumItem.name})`,
+              sortText: `3${value}`,
+              insertText: value,
+            }) satisfies ICompletionItem,
+        ),
       )
 
       items.push(...enumItems)

--- a/apps/desktop/src/routes/-components/actions-center.tsx
+++ b/apps/desktop/src/routes/-components/actions-center.tsx
@@ -1,6 +1,19 @@
 import type { connections, connectionsResources } from '~/drizzle/schema'
-import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@conar/ui/components/command'
-import { RiAddLine, RiDashboardLine, RiRefreshLine, RiTableLine } from '@remixicon/react'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@conar/ui/components/command'
+import {
+  RiAddLine,
+  RiDashboardLine,
+  RiEyeLine,
+  RiRefreshLine,
+  RiTableLine,
+} from '@remixicon/react'
 import { eq, useLiveQuery } from '@tanstack/react-db'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { useQuery } from '@tanstack/react-query'
@@ -10,14 +23,27 @@ import { ConnectionIcon } from '~/entities/connection/components'
 import { useConnectionResourceLinkParams } from '~/entities/connection/hooks'
 import { resourceTablesAndSchemasQuery } from '~/entities/connection/queries'
 import { getConnectionResourceStore } from '~/entities/connection/store'
-import { connectionsCollection, connectionsResourcesCollection } from '~/entities/connection/sync'
+import {
+  connectionsCollection,
+  connectionsResourcesCollection,
+} from '~/entities/connection/sync'
 import { prefetchConnectionResourceCore } from '~/entities/connection/utils'
 import { appStore, setIsActionCenterOpen } from '~/store'
 
-function ActionsResourceTables({ connection, connectionResource }: { connection: typeof connections.$inferSelect, connectionResource: typeof connectionsResources.$inferSelect }) {
+function ActionsResourceTables({
+  connection,
+  connectionResource,
+}: {
+  connection: typeof connections.$inferSelect
+  connectionResource: typeof connectionsResources.$inferSelect
+}) {
   const store = getConnectionResourceStore(connectionResource.id)
   const { data: tablesAndSchemas } = useQuery({
-    ...resourceTablesAndSchemasQuery({ silent: true, connectionResource, showSystem: store.get().showSystem }),
+    ...resourceTablesAndSchemasQuery({
+      silent: true,
+      connectionResource,
+      showSystem: store.get().showSystem,
+    }),
     throwOnError: false,
   })
   const router = useRouter()
@@ -27,33 +53,56 @@ function ActionsResourceTables({ connection, connectionResource }: { connection:
 
   function onTableSelect(schema: string, table: string) {
     setIsActionCenterOpen(false)
-    router.navigate({ to: '/connection/$resourceId/table', params: { resourceId: connectionResource.id }, search: { schema, table } })
+    router.navigate({
+      to: '/connection/$resourceId/table',
+      params: { resourceId: connectionResource.id },
+      search: { schema, table },
+    })
   }
 
   return (
-    <CommandGroup heading={`${connection.name} - ${connectionResource.name} Tables`} value={connectionResource.name}>
-      {tablesAndSchemas.schemas.map(schema => schema.tables.map(table => (
-        <CommandItem
-          key={table}
-          keywords={[schema.name, table]}
-          value={`${schema.name}.${table}`}
-          onSelect={() => onTableSelect(schema.name, table)}
-        >
-          <RiTableLine className="size-4 shrink-0 text-muted-foreground" />
-          {schema.name}
-          .
-          {table}
-        </CommandItem>
-      )))}
+    <CommandGroup
+      heading={`${connection.name} - ${connectionResource.name} Tables`}
+      value={connectionResource.name}
+    >
+      {tablesAndSchemas.schemas.map(schema =>
+        schema.tables.map(table => (
+          <CommandItem
+            key={table.name}
+            keywords={[schema.name, table.name]}
+            value={`${schema.name}.${table.name}`}
+            onSelect={() => onTableSelect(schema.name, table.name)}
+          >
+            {table.isView
+              ? (
+                  <RiEyeLine className="size-4 shrink-0 text-muted-foreground" />
+                )
+              : (
+                  <RiTableLine className="size-4 shrink-0 text-muted-foreground" />
+                )}
+            {schema.name}
+            .
+            {table.name}
+          </CommandItem>
+        )),
+      )}
     </CommandGroup>
   )
 }
 
-function ConnectionResource({ connection, connectionResource }: { connection: typeof connections.$inferSelect, connectionResource: typeof connectionsResources.$inferSelect }) {
+function ConnectionResource({
+  connection,
+  connectionResource,
+}: {
+  connection: typeof connections.$inferSelect
+  connectionResource: typeof connectionsResources.$inferSelect
+}) {
   const router = useRouter()
   const params = useConnectionResourceLinkParams(connectionResource.id)
 
-  function onResourceSelect(connectionResource: typeof connectionsResources.$inferSelect) {
+  function onResourceSelect(
+    connectionResource: typeof connectionsResources.$inferSelect,
+  ) {
     setIsActionCenterOpen(false)
 
     prefetchConnectionResourceCore(connectionResource)
@@ -61,21 +110,16 @@ function ConnectionResource({ connection, connectionResource }: { connection: ty
   }
 
   return (
-    <CommandItem
-      onSelect={() => onResourceSelect(connectionResource)}
-    >
-      <ConnectionIcon
-        type={connection.type}
-        className="size-4 shrink-0"
-      />
+    <CommandItem onSelect={() => onResourceSelect(connectionResource)}>
+      <ConnectionIcon type={connection.type} className="size-4 shrink-0" />
       <div className="flex items-center gap-2">
         {connection.name}
         {' '}
         -
-        {' '}
         {connectionResource.name}
         {connection.label && (
-          <span className={`
+          <span
+            className={`
             rounded-full bg-muted-foreground/10 px-2 py-0.5 text-xs
             whitespace-nowrap text-muted-foreground
           `}
@@ -90,18 +134,23 @@ function ConnectionResource({ connection, connectionResource }: { connection: ty
 
 export function ActionsCenter() {
   const { resourceId } = useParams({ strict: false })
-  const { data } = useLiveQuery(q => q
-    .from({ connections: connectionsCollection })
-    .innerJoin(
-      { connectionResources: connectionsResourcesCollection },
-      ({ connectionResources, connections }) => eq(connectionResources.connectionId, connections.id),
-    )
-    .select(({ connections, connectionResources }) => ({
-      connection: connections,
-      connectionResource: connectionResources,
-    }))
-    .orderBy(({ connections }) => connections.createdAt, 'desc'))
-  const isOpen = useSubscription(appStore, { selector: state => state.isActionCenterOpen })
+  const { data } = useLiveQuery(q =>
+    q
+      .from({ connections: connectionsCollection })
+      .innerJoin(
+        { connectionResources: connectionsResourcesCollection },
+        ({ connectionResources, connections }) =>
+          eq(connectionResources.connectionId, connections.id),
+      )
+      .select(({ connections, connectionResources }) => ({
+        connection: connections,
+        connectionResource: connectionResources,
+      }))
+      .orderBy(({ connections }) => connections.createdAt, 'desc'),
+  )
+  const isOpen = useSubscription(appStore, {
+    selector: state => state.isActionCenterOpen,
+  })
   const router = useRouter()
 
   useHotkey('Mod+P', () => {
@@ -111,7 +160,9 @@ export function ActionsCenter() {
     setIsActionCenterOpen(!isOpen)
   })
 
-  const current = data?.find(({ connectionResource }) => connectionResource.id === resourceId)
+  const current = data?.find(
+    ({ connectionResource }) => connectionResource.id === resourceId,
+  )
 
   return (
     <CommandDialog open={isOpen} onOpenChange={setIsActionCenterOpen}>
@@ -148,12 +199,21 @@ export function ActionsCenter() {
         </CommandGroup>
         {!!data.length && (
           <CommandGroup heading="Connections">
-            {data.map(({ connection, connectionResource }) =>
-              <ConnectionResource key={connectionResource.id} connection={connection} connectionResource={connectionResource} />,
-            )}
+            {data.map(({ connection, connectionResource }) => (
+              <ConnectionResource
+                key={connectionResource.id}
+                connection={connection}
+                connectionResource={connectionResource}
+              />
+            ))}
           </CommandGroup>
         )}
-        {current && <ActionsResourceTables connection={current.connection} connectionResource={current.connectionResource} />}
+        {current && (
+          <ActionsResourceTables
+            connection={current.connection}
+            connectionResource={current.connectionResource}
+          />
+        )}
       </CommandList>
     </CommandDialog>
   )

--- a/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/tables-tree.tsx
+++ b/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/tables-tree.tsx
@@ -1,15 +1,39 @@
 import type { ComponentRef } from 'react'
 import { ConnectionType } from '@conar/shared/enums/connection-type'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@conar/ui/components/accordion'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@conar/ui/components/accordion'
 import { Button } from '@conar/ui/components/button'
 import { HighlightText } from '@conar/ui/components/custom/highlight'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@conar/ui/components/dropdown-menu'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@conar/ui/components/dropdown-menu'
 import { ScrollArea } from '@conar/ui/components/scroll-area'
 import { SeparatorMotion } from '@conar/ui/components/separator'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@conar/ui/components/tooltip'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@conar/ui/components/tooltip'
 import { copy as copyToClipboard } from '@conar/ui/lib/copy'
 import { cn } from '@conar/ui/lib/utils'
-import { RiDeleteBin7Line, RiEditLine, RiFileCopyLine, RiMoreLine, RiPushpinFill, RiPushpinLine, RiStackLine, RiTableLine } from '@remixicon/react'
+import {
+  RiDeleteBin7Line,
+  RiEditLine,
+  RiEyeLine,
+  RiFileCopyLine,
+  RiMoreLine,
+  RiPushpinFill,
+  RiPushpinLine,
+  RiStackLine,
+  RiTableLine,
+} from '@remixicon/react'
 import { useQuery } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
 import { AnimatePresence, motion } from 'motion/react'
@@ -17,7 +41,12 @@ import { useEffect, useMemo, useRef } from 'react'
 import { useSubscription } from 'seitu/react'
 import { SidebarLink } from '~/components/sidebar-link'
 import { resourceTablesAndSchemasQuery } from '~/entities/connection/queries'
-import { addTab, cleanupPinnedTables, getConnectionResourceStore, togglePinTable } from '~/entities/connection/store'
+import {
+  addTab,
+  cleanupPinnedTables,
+  getConnectionResourceStore,
+  togglePinTable,
+} from '~/entities/connection/store'
 import { Route } from '..'
 import { DropTableDialog } from './drop-table-dialog'
 import { RenameTableDialog } from './rename-table-dialog'
@@ -33,7 +62,9 @@ const treeTransition = {
   height: { duration: 0.1 },
 }
 
-const skeletonWidths = Array.from({ length: 10 }).map(() => `${Math.random() * 40 + 30}%`)
+const skeletonWidths = Array.from({ length: 10 }).map(
+  () => `${Math.random() * 40 + 30}%`,
+)
 
 function Skeleton() {
   return (
@@ -51,15 +82,25 @@ function Skeleton() {
   )
 }
 
-function TableItem({ schema, table, pinned = false, search, onRename, onDrop }: {
+function TableItem({
+  schema,
+  table,
+  isView = false,
+  pinned = false,
+  search,
+  onRename,
+  onDrop,
+}: {
   schema: string
   table: string
+  isView?: boolean
   pinned?: boolean
   search?: string
   onRename: () => void
   onDrop: () => void
 }) {
   const { connectionResource } = Route.useRouteContext()
+  const Icon = isView ? RiEyeLine : RiTableLine
 
   return (
     <SidebarLink
@@ -72,7 +113,7 @@ function TableItem({ schema, table, pinned = false, search, onRename, onDrop }: 
     >
       {({ isActive }) => (
         <>
-          <RiTableLine
+          <Icon
             className={cn(
               'size-4 shrink-0 text-muted-foreground opacity-50',
               isActive && 'text-primary opacity-100',
@@ -99,8 +140,12 @@ function TableItem({ schema, table, pinned = false, search, onRename, onDrop }: 
             }}
           >
             {pinned
-              ? <RiPushpinFill className="size-3 text-primary" />
-              : <RiPushpinLine className="size-3" />}
+              ? (
+                  <RiPushpinFill className="size-3 text-primary" />
+                )
+              : (
+                  <RiPushpinLine className="size-3" />
+                )}
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -125,10 +170,7 @@ function TableItem({ schema, table, pinned = false, search, onRename, onDrop }: 
             >
               <RiMoreLine className="size-3" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="min-w-48"
-            >
+            <DropdownMenuContent align="end" className="min-w-48">
               <DropdownMenuItem
                 onClick={(e) => {
                   e.stopPropagation()
@@ -165,22 +207,54 @@ function TableItem({ schema, table, pinned = false, search, onRename, onDrop }: 
   )
 }
 
-export function TablesTree({ className, search }: { className?: string, search?: string }) {
+export function TablesTree({
+  className,
+  search,
+}: {
+  className?: string
+  search?: string
+}) {
   const { connection, connectionResource } = Route.useRouteContext()
   const store = getConnectionResourceStore(connectionResource.id)
-  const showSystem = useSubscription(store, { selector: state => state.showSystem })
-  const { data: tablesAndSchemas, isPending } = useQuery(resourceTablesAndSchemasQuery({ silent: false, connectionResource, showSystem }))
-  const { schema: schemaParam } = useSearch({ from: '/_protected/connection/$resourceId/table/' })
-  const tablesTreeOpenedSchemas = useSubscription(store, { selector: state => state.tablesTreeOpenedSchemas ?? [tablesAndSchemas?.schemas[0]?.name ?? 'public'] })
-  const pinnedTables = useSubscription(store, { selector: state => state.pinnedTables })
+  const showSystem = useSubscription(store, {
+    selector: state => state.showSystem,
+  })
+  const { data: tablesAndSchemas, isPending } = useQuery(
+    resourceTablesAndSchemasQuery({
+      silent: false,
+      connectionResource,
+      showSystem,
+    }),
+  )
+  const { schema: schemaParam } = useSearch({
+    from: '/_protected/connection/$resourceId/table/',
+  })
+  const tablesTreeOpenedSchemas = useSubscription(store, {
+    selector: state =>
+      state.tablesTreeOpenedSchemas ?? [
+        tablesAndSchemas?.schemas[0]?.name ?? 'public',
+      ],
+  })
+  const pinnedTables = useSubscription(store, {
+    selector: state => state.pinnedTables,
+  })
   const dropTableDialogRef = useRef<ComponentRef<typeof DropTableDialog>>(null)
-  const renameTableDialogRef = useRef<ComponentRef<typeof RenameTableDialog>>(null)
+  const renameTableDialogRef
+    = useRef<ComponentRef<typeof RenameTableDialog>>(null)
 
   useEffect(() => {
     if (!tablesAndSchemas)
       return
 
-    cleanupPinnedTables(connectionResource.id, tablesAndSchemas.schemas.flatMap(schema => schema.tables.map(table => ({ schema: schema.name, table }))))
+    cleanupPinnedTables(
+      connectionResource.id,
+      tablesAndSchemas.schemas.flatMap(schema =>
+        schema.tables.map(table => ({
+          schema: schema.name,
+          table: table.name,
+        })),
+      ),
+    )
   }, [connectionResource, tablesAndSchemas])
 
   const filteredTablesAndSchemas = useMemo(() => {
@@ -190,21 +264,27 @@ export function TablesTree({ className, search }: { className?: string, search?:
     const schemas = tablesAndSchemas.schemas
       .map(schema => ({
         ...schema,
-        tables: schema.tables.filter(table =>
-          !search
-          || table.toLowerCase().includes(search.toLowerCase()),
-        ).toSorted((a, b) => a.localeCompare(b)),
+        tables: schema.tables
+          .filter(
+            table =>
+              !search
+              || table.name.toLowerCase().includes(search.toLowerCase()),
+          )
+          .toSorted((a, b) => a.name.localeCompare(b.name)),
       }))
       .filter(schema => schema.tables.length)
 
-    const pinnedSet = new Set(pinnedTables.map(t => `${t.schema}:${t.table}`))
+    const pinnedSet = new Set(
+      pinnedTables.map(t => `${t.schema}:${t.table}`),
+    )
 
     return schemas.map((schema) => {
-      const pinned: string[] = []
-      const unpinned: string[] = []
+      interface TableEntry { name: string, isView: boolean }
+      const pinned: TableEntry[] = []
+      const unpinned: TableEntry[] = []
 
       schema.tables.forEach((table) => {
-        const isPinned = pinnedSet.has(`${schema.name}:${table}`)
+        const isPinned = pinnedSet.has(`${schema.name}:${table.name}`)
         if (isPinned) {
           pinned.push(table)
         }
@@ -221,9 +301,13 @@ export function TablesTree({ className, search }: { className?: string, search?:
     })
   }, [search, tablesAndSchemas, pinnedTables])
 
-  const searchAccordionValue = useMemo(() => search
-    ? filteredTablesAndSchemas.map(schema => schema.name)
-    : tablesTreeOpenedSchemas, [search, filteredTablesAndSchemas, tablesTreeOpenedSchemas])
+  const searchAccordionValue = useMemo(
+    () =>
+      search
+        ? filteredTablesAndSchemas.map(schema => schema.name)
+        : tablesTreeOpenedSchemas,
+    [search, filteredTablesAndSchemas, tablesTreeOpenedSchemas],
+  )
 
   return (
     <ScrollArea className={cn('h-full p-2', className)} scrollFade>
@@ -233,10 +317,13 @@ export function TablesTree({ className, search }: { className?: string, search?:
         value={searchAccordionValue}
         onValueChange={(v) => {
           if (!search) {
-            store.set(state => ({
-              ...state,
-              tablesTreeOpenedSchemas: v,
-            } satisfies typeof state))
+            store.set(
+              state =>
+                ({
+                  ...state,
+                  tablesTreeOpenedSchemas: v,
+                }) satisfies typeof state,
+            )
           }
         }}
         data-mask
@@ -245,7 +332,8 @@ export function TablesTree({ className, search }: { className?: string, search?:
       >
         {isPending
           ? (
-              <div className={`
+              <div
+                className={`
                 flex h-full flex-1 flex-col items-center justify-center
                 text-center
               `}
@@ -255,7 +343,8 @@ export function TablesTree({ className, search }: { className?: string, search?:
             )
           : filteredTablesAndSchemas.length === 0
             ? (
-                <div className={`
+                <div
+                  className={`
                   flex h-full flex-1 flex-col items-center justify-center py-8
                   text-center
                 `}
@@ -274,12 +363,10 @@ export function TablesTree({ className, search }: { className?: string, search?:
                       exit={{ opacity: 0, height: 0 }}
                       transition={{ duration: 0.2 }}
                     >
-                      <AccordionItem
-                        value={schema.name}
-                        className="border-b-0"
-                      >
+                      <AccordionItem value={schema.name} className="border-b-0">
                         {connection.type !== ConnectionType.ClickHouse && (
-                          <AccordionTrigger className={`
+                          <AccordionTrigger
+                            className={`
                             mb-1 cursor-pointer truncate px-2 py-1.5
                             hover:bg-accent/50 hover:no-underline
                           `}
@@ -293,15 +380,14 @@ export function TablesTree({ className, search }: { className?: string, search?:
                                         size-4 shrink-0 text-muted-foreground
                                         opacity-50
                                       `,
-                                      schemaParam === schema.name && `
+                                      schemaParam === schema.name
+                                      && `
                                         text-primary opacity-100
                                       `,
                                     )}
                                   />
                                 </TooltipTrigger>
-                                <TooltipContent>
-                                  Schema
-                                </TooltipContent>
+                                <TooltipContent>Schema</TooltipContent>
                               </Tooltip>
                               {schema.name}
                             </span>
@@ -311,7 +397,7 @@ export function TablesTree({ className, search }: { className?: string, search?:
                           <AnimatePresence mode="popLayout">
                             {schema.pinnedTables.map(table => (
                               <motion.div
-                                key={`${schema.name}:${table}`}
+                                key={`${schema.name}:${table.name}`}
                                 layout
                                 variants={treeVariants}
                                 initial={search ? treeVariants.hidden : false}
@@ -321,15 +407,25 @@ export function TablesTree({ className, search }: { className?: string, search?:
                               >
                                 <TableItem
                                   schema={schema.name}
-                                  table={table}
+                                  table={table.name}
+                                  isView={table.isView}
                                   pinned
                                   search={search}
-                                  onRename={() => renameTableDialogRef.current?.rename(schema.name, table)}
-                                  onDrop={() => dropTableDialogRef.current?.drop(schema.name, table)}
+                                  onRename={() =>
+                                    renameTableDialogRef.current?.rename(
+                                      schema.name,
+                                      table.name,
+                                    )}
+                                  onDrop={() =>
+                                    dropTableDialogRef.current?.drop(
+                                      schema.name,
+                                      table.name,
+                                    )}
                                 />
                               </motion.div>
                             ))}
-                            {schema.pinnedTables.length > 0 && schema.unpinnedTables.length > 0 && (
+                            {schema.pinnedTables.length > 0
+                              && schema.unpinnedTables.length > 0 && (
                               <SeparatorMotion
                                 className="my-2 h-px!"
                                 layout
@@ -342,7 +438,7 @@ export function TablesTree({ className, search }: { className?: string, search?:
                             )}
                             {schema.unpinnedTables.map(table => (
                               <motion.div
-                                key={`${schema.name}:${table}`}
+                                key={`${schema.name}:${table.name}`}
                                 layout
                                 variants={treeVariants}
                                 initial={search ? treeVariants.hidden : false}
@@ -352,10 +448,19 @@ export function TablesTree({ className, search }: { className?: string, search?:
                               >
                                 <TableItem
                                   schema={schema.name}
-                                  table={table}
+                                  table={table.name}
+                                  isView={table.isView}
                                   search={search}
-                                  onRename={() => renameTableDialogRef.current?.rename(schema.name, table)}
-                                  onDrop={() => dropTableDialogRef.current?.drop(schema.name, table)}
+                                  onRename={() =>
+                                    renameTableDialogRef.current?.rename(
+                                      schema.name,
+                                      table.name,
+                                    )}
+                                  onDrop={() =>
+                                    dropTableDialogRef.current?.drop(
+                                      schema.name,
+                                      table.name,
+                                    )}
                                 />
                               </motion.div>
                             ))}

--- a/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/tabs.tsx
+++ b/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/tabs.tsx
@@ -11,7 +11,11 @@ import {
   ContextMenuTrigger,
 } from '@conar/ui/components/context-menu'
 import { ScrollArea } from '@conar/ui/components/scroll-area'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@conar/ui/components/tooltip'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@conar/ui/components/tooltip'
 import { useIsInViewport } from '@conar/ui/hookas/use-is-in-viewport'
 import { cn } from '@conar/ui/lib/utils'
 import { RiCloseLine, RiTableLine } from '@remixicon/react'
@@ -22,14 +26,23 @@ import { Reorder } from 'motion/react'
 import { useEffect, useEffectEvent, useRef, useState } from 'react'
 import { useSubscription } from 'seitu/react'
 import { resourceTablesAndSchemasQuery } from '~/entities/connection/queries'
-import { addTab, getConnectionResourceStore, removeTab, updateTabs } from '~/entities/connection/store'
+import {
+  addTab,
+  getConnectionResourceStore,
+  removeTab,
+  updateTabs,
+} from '~/entities/connection/store'
 import { prefetchConnectionResourceTableCore } from '~/entities/connection/utils'
 import { Route } from '..'
 import { tablePageStore } from '../-store'
 
 const os = getOS(navigator.userAgent)
 
-function CloseButton({ onClick }: { onClick: ComponentProps<'svg'>['onClick'] }) {
+function CloseButton({
+  onClick,
+}: {
+  onClick: ComponentProps<'svg'>['onClick']
+}) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -52,8 +65,16 @@ function CloseButton({ onClick }: { onClick: ComponentProps<'svg'>['onClick'] })
   )
 }
 
-function getQueryOpts(connectionResource: typeof connectionsResources.$inferSelect, schema: string, tableName: string) {
-  const store = tablePageStore({ id: connectionResource.id, schema, table: tableName })
+function getQueryOpts(
+  connectionResource: typeof connectionsResources.$inferSelect,
+  schema: string,
+  tableName: string,
+) {
+  const store = tablePageStore({
+    id: connectionResource.id,
+    schema,
+    table: tableName,
+  })
 
   return {
     filters: store.get().filters,
@@ -73,7 +94,10 @@ function SortableTab({
   currentTabIndex,
   totalTabs,
 }: {
-  item: { id: string, tab: typeof connectionResourceType.infer['tabs'][number] }
+  item: {
+    id: string
+    tab: (typeof connectionResourceType.infer)['tabs'][number]
+  }
   showSchema: boolean
   connectionResource: typeof connectionsResources.$inferSelect
   onClose: VoidFunction
@@ -84,12 +108,15 @@ function SortableTab({
   totalTabs: number
 }) {
   const router = useRouter()
-  const { schema: schemaParam, table: tableParam } = useSearch({ from: '/_protected/connection/$resourceId/table/' })
+  const { schema: schemaParam, table: tableParam } = useSearch({
+    from: '/_protected/connection/$resourceId/table/',
+  })
   const ref = useRef<HTMLDivElement>(null)
   const isVisible = useIsInViewport(ref, 'full')
   const [contextMenuOpen, setContextMenuOpen] = useState(false)
 
-  const isActive = schemaParam === item.tab.schema && tableParam === item.tab.table
+  const isActive
+    = schemaParam === item.tab.schema && tableParam === item.tab.table
 
   useEffect(() => {
     if (!isVisible && isActive && ref.current) {
@@ -124,23 +151,36 @@ function SortableTab({
                 border-transparent pr-1.5 pl-2 text-sm text-foreground
                 hover:border-accent hover:bg-muted/70
               `,
-              isActive && `
+              isActive
+              && `
                 border-primary/50 bg-primary/10
                 hover:border-primary/50 hover:bg-primary/10
               `,
             )}
-            onDoubleClick={() => addTab(connectionResource.id, item.tab.schema, item.tab.table, false)}
-            onMouseOver={() => prefetchConnectionResourceTableCore({
-              connectionResource,
-              schema: item.tab.schema,
-              table: item.tab.table,
-              query: getQueryOpts(connectionResource, item.tab.schema, item.tab.table),
-            })}
-            onClick={() => router.navigate({
-              to: '/connection/$resourceId/table',
-              params: { resourceId: connectionResource.id },
-              search: { schema: item.tab.schema, table: item.tab.table },
-            })}
+            onDoubleClick={() =>
+              addTab(
+                connectionResource.id,
+                item.tab.schema,
+                item.tab.table,
+                false,
+              )}
+            onMouseOver={() =>
+              prefetchConnectionResourceTableCore({
+                connectionResource,
+                schema: item.tab.schema,
+                table: item.tab.table,
+                query: getQueryOpts(
+                  connectionResource,
+                  item.tab.schema,
+                  item.tab.table,
+                ),
+              })}
+            onClick={() =>
+              router.navigate({
+                to: '/connection/$resourceId/table',
+                params: { resourceId: connectionResource.id },
+                search: { schema: item.tab.schema, table: item.tab.table },
+              })}
           >
             <RiTableLine
               className={cn(
@@ -175,7 +215,10 @@ function SortableTab({
           <ContextMenuItem onClick={onCloseOthers} disabled={totalTabs <= 1}>
             Close Others
           </ContextMenuItem>
-          <ContextMenuItem onClick={onCloseToTheRight} disabled={currentTabIndex >= totalTabs - 1}>
+          <ContextMenuItem
+            onClick={onCloseToTheRight}
+            disabled={currentTabIndex >= totalTabs - 1}
+          >
             Close to the Right
           </ContextMenuItem>
           <ContextMenuSeparator />
@@ -188,21 +231,29 @@ function SortableTab({
   )
 }
 
-export function TablesTabs({
-  className,
-}: {
-  className?: string
-}) {
+export function TablesTabs({ className }: { className?: string }) {
   const { connectionResource } = Route.useRouteContext()
   const store = getConnectionResourceStore(connectionResource.id)
-  const showSystem = useSubscription(store, { selector: state => state.showSystem })
-  const { data: tablesAndSchemas } = useQuery(resourceTablesAndSchemasQuery({ silent: false, connectionResource, showSystem }))
-  const { schema: schemaParam, table: tableParam } = useSearch({ from: '/_protected/connection/$resourceId/table/' })
+  const showSystem = useSubscription(store, {
+    selector: state => state.showSystem,
+  })
+  const { data: tablesAndSchemas } = useQuery(
+    resourceTablesAndSchemasQuery({
+      silent: false,
+      connectionResource,
+      showSystem,
+    }),
+  )
+  const { schema: schemaParam, table: tableParam } = useSearch({
+    from: '/_protected/connection/$resourceId/table/',
+  })
   const router = useRouter()
   const tabs = useSubscription(store, { selector: state => state.tabs })
 
   const addNewTab = useEffectEvent((schema: string, table: string) => {
-    const tab = tabs.find(tab => tab.table === table && tab.schema === schema)
+    const tab = tabs.find(
+      tab => tab.table === table && tab.schema === schema,
+    )
 
     if (tab) {
       return
@@ -229,14 +280,18 @@ export function TablesTabs({
   }
 
   async function closeTabsToTheRight(schema: string, table: string) {
-    const currentIndex = tabs.findIndex(tab => tab.schema === schema && tab.table === table)
+    const currentIndex = tabs.findIndex(
+      tab => tab.schema === schema && tab.table === table,
+    )
 
     if (currentIndex === -1 || currentIndex >= tabs.length - 1) {
       return
     }
 
     const tabsToClose = tabs.slice(currentIndex + 1)
-    const isActiveTabOnTheRight = tabsToClose.some(tab => tab.schema === schemaParam && tab.table === tableParam)
+    const isActiveTabOnTheRight = tabsToClose.some(
+      tab => tab.schema === schemaParam && tab.table === tableParam,
+    )
 
     if (isActiveTabOnTheRight) {
       const leftTab = tabs[currentIndex]!
@@ -254,7 +309,9 @@ export function TablesTabs({
   }
 
   async function closeOtherTabs(schema: string, table: string) {
-    const tabsToClose = tabs.filter(tab => tab.schema !== schema || tab.table !== table)
+    const tabsToClose = tabs.filter(
+      tab => tab.schema !== schema || tab.table !== table,
+    )
 
     if (tabsToClose.length === 0) {
       return
@@ -283,17 +340,26 @@ export function TablesTabs({
     addNewTab(schemaParam, tableParam)
   }, [schemaParam, tableParam])
 
-  async function navigateToDifferentTabIfThisActive(schema: string, table: string) {
+  async function navigateToDifferentTabIfThisActive(
+    schema: string,
+    table: string,
+  ) {
     // If this tab is not opened, do not navigate
     if (schemaParam !== schema || tableParam !== table) {
       return
     }
 
-    const currentTabIndex = tabs.findIndex(tab => tab.schema === schema && tab.table === table)
-    const nextTabIndex = currentTabIndex === tabs.length - 1 ? null : currentTabIndex + 1
+    const currentTabIndex = tabs.findIndex(
+      tab => tab.schema === schema && tab.table === table,
+    )
+    const nextTabIndex
+      = currentTabIndex === tabs.length - 1 ? null : currentTabIndex + 1
     const prevTabIndex = currentTabIndex === 0 ? null : currentTabIndex - 1
 
-    const newTab = nextTabIndex !== null || prevTabIndex !== null ? tabs[(nextTabIndex ?? prevTabIndex)!] : null
+    const newTab
+      = nextTabIndex !== null || prevTabIndex !== null
+        ? tabs[(nextTabIndex ?? prevTabIndex)!]
+        : null
 
     if (newTab) {
       await router.navigate({
@@ -321,24 +387,36 @@ export function TablesTabs({
     }
   })
 
-  const cleanupTabsEvent = useEffectEvent(async (tables: { schema: string, table: string }[]) => {
-    const tabsToRemove = tabs.filter(tab => !tables.some(t => t.schema === tab.schema && t.table === tab.table))
+  const cleanupTabsEvent = useEffectEvent(
+    async (tables: { schema: string, table: string }[]) => {
+      const tabsToRemove = tabs.filter(
+        tab =>
+          !tables.some(t => t.schema === tab.schema && t.table === tab.table),
+      )
 
-    for (const { schema, table } of tabsToRemove) {
-      closeTab(schema, table)
-    }
-  })
+      for (const { schema, table } of tabsToRemove) {
+        closeTab(schema, table)
+      }
+    },
+  )
 
   useEffect(() => {
     if (!tablesAndSchemas)
       return
 
-    cleanupTabsEvent(tablesAndSchemas.schemas
-      .flatMap(schema => schema.tables.map(table => ({ schema: schema.name, table }))))
+    cleanupTabsEvent(
+      tablesAndSchemas.schemas.flatMap(schema =>
+        schema.tables.map(table => ({
+          schema: schema.name,
+          table: table.name,
+        })),
+      ),
+    )
   }, [tablesAndSchemas])
 
   const isOneSchema = tabs.length
-    ? tabs.every(tab => tab.schema === tabs[0]?.schema) && schemaParam === tabs[0]?.schema
+    ? tabs.every(tab => tab.schema === tabs[0]?.schema)
+    && schemaParam === tabs[0]?.schema
     : true
 
   const tabItems = tabs.map(tab => ({
@@ -352,7 +430,10 @@ export function TablesTabs({
         axis="x"
         values={tabItems}
         onReorder={(newItems) => {
-          updateTabs(connectionResource.id, newItems.map(item => item.tab))
+          updateTabs(
+            connectionResource.id,
+            newItems.map(item => item.tab),
+          )
         }}
         className="flex h-full gap-1 p-1"
       >
@@ -364,8 +445,10 @@ export function TablesTabs({
             showSchema={!isOneSchema}
             onClose={() => closeTab(item.tab.schema, item.tab.table)}
             onCloseAll={closeAllTabs}
-            onCloseToTheRight={() => closeTabsToTheRight(item.tab.schema, item.tab.table)}
-            onCloseOthers={() => closeOtherTabs(item.tab.schema, item.tab.table)}
+            onCloseToTheRight={() =>
+              closeTabsToTheRight(item.tab.schema, item.tab.table)}
+            onCloseOthers={() =>
+              closeOtherTabs(item.tab.schema, item.tab.table)}
             currentTabIndex={index}
             totalTabs={tabItems.length}
           />

--- a/apps/desktop/src/routes/_protected/connection/$resourceId/visualizer/index.tsx
+++ b/apps/desktop/src/routes/_protected/connection/$resourceId/visualizer/index.tsx
@@ -1,23 +1,45 @@
-import type { constraintsType, tablesAndSchemasType } from '~/entities/connection/queries'
+import type { constraintsType } from '~/entities/connection/queries'
 import type { columnType } from '~/entities/connection/queries/columns'
 import { title } from '@conar/shared/utils/title'
 import { AppLogo } from '@conar/ui/components/brand/app-logo'
 import { CtrlLetter } from '@conar/ui/components/custom/shortcuts'
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@conar/ui/components/input-group'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@conar/ui/components/input-group'
 import { Kbd } from '@conar/ui/components/kbd'
 import { ReactFlowEdge } from '@conar/ui/components/react-flow/edge'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@conar/ui/components/select'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@conar/ui/components/select'
 import { useMountedEffect } from '@conar/ui/hookas/use-mounted-effect'
 import { RiCloseLine, RiSearchLine } from '@remixicon/react'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Background, BackgroundVariant, MiniMap, ReactFlow, ReactFlowProvider, useEdgesState, useNodesState } from '@xyflow/react'
+import {
+  Background,
+  BackgroundVariant,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+} from '@xyflow/react'
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useSubscription } from 'seitu/react'
 import { animationHooks } from '~/enter'
 import { ReactFlowNode } from '~/entities/connection/components'
-import { resourceConstraintsQuery, resourceTableColumnsQuery, resourceTablesAndSchemasQuery } from '~/entities/connection/queries'
+import {
+  resourceConstraintsQuery,
+  resourceTableColumnsQuery,
+  resourceTablesAndSchemasQuery,
+} from '~/entities/connection/queries'
 import { getConnectionResourceStore } from '~/entities/connection/store'
 import { prefetchConnectionResourceCore } from '~/entities/connection/utils'
 import { applySearchHighlight, getVisualizerLayout } from './-lib'
@@ -28,10 +50,23 @@ export const Route = createFileRoute(
   component: VisualizerPage,
   loader: ({ context }) => {
     prefetchConnectionResourceCore(context.connectionResource)
-    return { connection: context.connection, connectionResource: context.connectionResource }
+    return {
+      connection: context.connection,
+      connectionResource: context.connectionResource,
+    }
   },
   head: ({ loaderData }) => ({
-    meta: loaderData ? [{ title: title('Visualizer', loaderData.connection.name, loaderData.connectionResource.name) }] : [],
+    meta: loaderData
+      ? [
+          {
+            title: title(
+              'Visualizer',
+              loaderData.connection.name,
+              loaderData.connectionResource.name,
+            ),
+          },
+        ]
+      : [],
   }),
 })
 
@@ -39,21 +74,38 @@ function VisualizerPage() {
   const { connection } = Route.useLoaderData()
   const { connectionResource } = Route.useRouteContext()
   const store = getConnectionResourceStore(connectionResource.id)
-  const showSystem = useSubscription(store, { selector: state => state.showSystem })
+  const showSystem = useSubscription(store, {
+    selector: state => state.showSystem,
+  })
   const { data: tablesAndSchemas } = useQuery({
-    ...resourceTablesAndSchemasQuery({ silent: false, connectionResource, showSystem }),
-    select: data => data.schemas.flatMap(({ name, tables }) => tables.map(table => ({ schema: name, table }))),
+    ...resourceTablesAndSchemasQuery({
+      silent: false,
+      connectionResource,
+      showSystem,
+    }),
+    select: data =>
+      data.schemas.flatMap(({ name, tables }) =>
+        tables.map(table => ({ schema: name, table: table.name })),
+      ),
   })
   const columnsQueries = useQueries({
-    queries: tablesAndSchemas?.flatMap(({ schema, table }) =>
-      resourceTableColumnsQuery({ connectionResource, schema, table }),
-    ) ?? [],
+    queries:
+      tablesAndSchemas?.flatMap(({ schema, table }) =>
+        resourceTableColumnsQuery({ connectionResource, schema, table }),
+      ) ?? [],
   })
-  const { data: constraints } = useQuery(resourceConstraintsQuery({ connectionResource }))
+  const { data: constraints } = useQuery(
+    resourceConstraintsQuery({ connectionResource }),
+  )
 
-  if (!tablesAndSchemas || !constraints || columnsQueries.some(q => q.isPending)) {
+  if (
+    !tablesAndSchemas
+    || !constraints
+    || columnsQueries.some(q => q.isPending)
+  ) {
     return (
-      <div className="
+      <div
+        className="
         flex size-full items-center justify-center rounded-lg border
         bg-background
       "
@@ -63,11 +115,14 @@ function VisualizerPage() {
     )
   }
 
-  const columns = columnsQueries.flatMap(item => item.data).filter((item): item is typeof columnType.infer => !!item)
+  const columns = columnsQueries
+    .flatMap(item => item.data)
+    .filter((item): item is typeof columnType.infer => !!item)
 
   if (columns.length === 0 || tablesAndSchemas.length === 0) {
     return (
-      <div className="
+      <div
+        className="
         flex size-full items-center justify-center rounded-lg border
         bg-background
       "
@@ -101,9 +156,9 @@ function Visualizer({
   columns,
   constraints,
 }: {
-  tablesAndSchemas: typeof tablesAndSchemasType.infer[]
-  columns: typeof columnType.infer[]
-  constraints: typeof constraintsType.infer[]
+  tablesAndSchemas: { schema: string, table: string }[]
+  columns: (typeof columnType.infer)[]
+  constraints: (typeof constraintsType.infer)[]
 }) {
   const { connectionResource } = Route.useRouteContext()
   const schemas = [...new Set(tablesAndSchemas.map(({ schema }) => schema))]
@@ -113,9 +168,12 @@ function Visualizer({
 
   const trimmedSearchQuery = searchQuery.trim().toLowerCase()
   const schemaConstraints = constraints.filter(
-    c => c.schema === schema && (!c.foreignSchema || c.foreignSchema === schema),
+    c =>
+      c.schema === schema && (!c.foreignSchema || c.foreignSchema === schema),
   )
-  const tables = tablesAndSchemas.filter(t => t.schema === schema).map(({ table }) => table)
+  const tables = tablesAndSchemas
+    .filter(t => t.schema === schema)
+    .map(({ table }) => table)
 
   const { nodes: layoutNodes, edges: layoutEdges } = useMemo(() => {
     return getVisualizerLayout({
@@ -139,12 +197,14 @@ function Visualizer({
       constraints: schemaConstraints,
     })
 
-    setNodes(applySearchHighlight({
-      nodes,
-      searchQuery: trimmedSearchQuery,
-      tables,
-      columns,
-    }))
+    setNodes(
+      applySearchHighlight({
+        nodes,
+        searchQuery: trimmedSearchQuery,
+        tables,
+        columns,
+      }),
+    )
     setEdges(edges)
   }
 
@@ -179,23 +239,27 @@ function Visualizer({
               autoFocus
               onChange={(e) => {
                 setSearchQuery(e.target.value)
-                setNodes(nodes => applySearchHighlight({
-                  nodes,
-                  searchQuery: e.target.value.trim(),
-                  tables,
-                  columns,
-                }))
+                setNodes(nodes =>
+                  applySearchHighlight({
+                    nodes,
+                    searchQuery: e.target.value.trim(),
+                    tables,
+                    columns,
+                  }),
+                )
               }}
             />
             <InputGroupAddon>
-              <RiSearchLine className="
+              <RiSearchLine
+                className="
                 pointer-events-none size-3.5 text-muted-foreground
               "
               />
             </InputGroupAddon>
             <InputGroupAddon align="inline-end">
               {!searchQuery && (
-                <div className="
+                <div
+                  className="
                   pointer-events-none flex items-center gap-1 text-xs
                   text-muted-foreground
                 "
@@ -228,14 +292,15 @@ function Visualizer({
           }}
         >
           <SelectTrigger className="max-w-56 min-w-[180px]">
-            <div className="
+            <div
+              className="
               flex flex-1 items-center gap-2 overflow-hidden text-left
             "
             >
-              <span className="shrink-0 text-muted-foreground">
-                schema
+              <span className="shrink-0 text-muted-foreground">schema</span>
+              <span className="truncate">
+                <SelectValue placeholder="Select schema" />
               </span>
-              <span className="truncate"><SelectValue placeholder="Select schema" /></span>
             </div>
           </SelectTrigger>
           <SelectContent>
@@ -272,7 +337,12 @@ function Visualizer({
         }}
         attributionPosition="bottom-left"
       >
-        <Background bgColor="var(--background)" variant={BackgroundVariant.Dots} gap={20} size={2} />
+        <Background
+          bgColor="var(--background)"
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={2}
+        />
         <MiniMap
           pannable
           zoomable


### PR DESCRIPTION
## Description of Changes

- Include database views (not just base tables) in the sidebar tree, command palette, and SQL autocompletion for all 4 dialects (PostgreSQL, MySQL, MSSQL, ClickHouse)
- Views are visually distinguished with an eye icon (`RiEyeLine`) while tables keep the existing table icon (`RiTableLine`)
- Monaco autocompletion now shows "view" vs "table" in the detail label
- The `information_schema.tables` query filter changed from `= 'BASE TABLE'` to `in ['BASE TABLE', 'VIEW']`, and `table_type` is now included in the select

Closes #181

## Files Changed

| File | Change |
|------|--------|
| `tables-and-schemas.ts` | Query includes VIEWs, selects `table_type`, maps `isView` boolean |
| `tables-tree.tsx` | Eye icon for views in sidebar tree |
| `actions-center.tsx` | Eye icon for views in command palette |
| `monaco.ts` | Autocompletion shows "view" vs "table" detail |
| `tabs.tsx` | Updated table name mapping |
| `visualizer/index.tsx` | Updated table name mapping, removed unused import |

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- The type definitions already had `'BASE TABLE' | 'VIEW'` variants but the query never used `VIEW` — this PR closes that gap
- All 4 dialects are updated consistently
- No breaking changes to the pinning, tabs, or visualizer features — they continue to work with the new data shape