### PR TITLE
feat: change free AI filters usage to daily limit of 10

### DIFF
--- a/apps/api/orpc/routers/ai/filters.ts
+++ b/apps/api/orpc/routers/ai/filters.ts
@@ -1,9 +1,9 @@
 import { google } from '@ai-sdk/google'
-import { FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT } from '@conar/shared/constants'
+import { FREE_AI_FILTERS_USAGE_DAILY_LIMIT } from '@conar/shared/constants'
 import { SQL_FILTERS_GROUPED, SQL_FILTERS_LIST } from '@conar/shared/filters'
 import { generateText, Output } from 'ai'
 import { type } from 'arktype'
-import { addDays, differenceInSeconds, endOfMonth, format } from 'date-fns'
+import { addDays, differenceInSeconds, format, startOfDay } from 'date-fns'
 import * as z from 'zod/mini'
 import { withPosthog } from '~/lib/posthog'
 import { redis } from '~/lib/redis'
@@ -24,14 +24,15 @@ const schema = z.object({
 
 const redisUsage = {
   get: async (userId: string) => {
-    const value = await redis.get(`ai:usage:${userId}:filters:${format(new Date(), 'yyyy-MM')}`)
+    const value = await redis.get(`ai:usage:${userId}:filters:${format(new Date(), 'yyyy-MM-dd')}`)
     return value ? Number(value) : 0
   },
   increment: async (userId: string) => {
     const now = new Date()
-    const key = `ai:usage:${userId}:filters:${format(now, 'yyyy-MM')}`
+    const key = `ai:usage:${userId}:filters:${format(now, 'yyyy-MM-dd')}`
     const value = await redis.incr(key)
-    await redis.expire(key, differenceInSeconds(endOfMonth(now), now))
+    const resetAt = addDays(startOfDay(now), 1)
+    await redis.expire(key, Math.max(1, differenceInSeconds(resetAt, now)))
     return value
   },
 }
@@ -62,13 +63,13 @@ export const filters = orpc
     if (!context.subscription) {
       usage = await redisUsage.get(context.user.id)
 
-      if (usage >= FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT) {
+      if (usage >= FREE_AI_FILTERS_USAGE_DAILY_LIMIT) {
         throw errors.FORBIDDEN({
           message: 'You have reached the free AI usage limit. Please subscribe to a Pro plan to continue using AI features.',
           data: {
             remaining: 0,
-            max: FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT,
-            resetAt: addDays(endOfMonth(new Date()), 1),
+            max: FREE_AI_FILTERS_USAGE_DAILY_LIMIT,
+            resetAt: addDays(startOfDay(new Date()), 1),
           },
         })
       }
@@ -125,7 +126,7 @@ export const filters = orpc
       usage = await redisUsage.increment(context.user.id)
     }
 
-    const remainingFreeAiUsage = context.subscription ? null : FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT - usage
+    const remainingFreeAiUsage = context.subscription ? null : FREE_AI_FILTERS_USAGE_DAILY_LIMIT - usage
 
     context.addLogData({
       filterResult: result,
@@ -138,8 +139,8 @@ export const filters = orpc
       ...(remainingFreeAiUsage !== null && {
         freeAiUsage: {
           remaining: remainingFreeAiUsage,
-          max: FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT,
-          resetAt: addDays(endOfMonth(new Date()), 1),
+          max: FREE_AI_FILTERS_USAGE_DAILY_LIMIT,
+          resetAt: addDays(startOfDay(new Date()), 1),
         },
       }),
     }

--- a/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/header/header-search.tsx
+++ b/apps/desktop/src/routes/_protected/connection/$resourceId/table/-components/header/header-search.tsx
@@ -121,7 +121,7 @@ export function HeaderSearch({ table, schema }: { table: string, schema: string 
                     cursor-help text-xs whitespace-nowrap text-muted-foreground
                   "
                   tabIndex={0}
-                  aria-label={`You have ${freeAiUsage.remaining} out of ${freeAiUsage.max} free AI filter uses left this month.`}
+                  aria-label={`You have ${freeAiUsage.remaining} out of ${freeAiUsage.max} free AI filter uses left today.`}
                 >
                   <NumberFlow
                     value={freeAiUsage.remaining}
@@ -138,9 +138,9 @@ export function HeaderSearch({ table, schema }: { table: string, schema: string 
                 /
                 {freeAiUsage.max}
                 {' '}
-                free AI filter uses left this month. Reset at
+                free AI filter uses left today. Reset at
                 {' '}
-                {format(freeAiUsage.resetAt, 'MMM d, yyyy')}
+                {format(freeAiUsage.resetAt, 'MMM d, yyyy HH:mm')}
                 .
               </TooltipContent>
             </Tooltip>

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -46,7 +46,7 @@ export const LATEST_VERSION_BEFORE_SUBSCRIPTION = 26 as const
 export const SUBSCRIPTION_PAST_DUE_MESSAGE = 'We couldn\'t process your recent payment. Please update your payment method to avoid any interruption to your subscription.' as const
 export const ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing', 'past_due'] as const
 
-export const FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT = 50 as const
+export const FREE_AI_FILTERS_USAGE_DAILY_LIMIT = 10 as const
 
 export const CONNECTION_RESOURCE_ROOT_SYMBOL = Symbol('CONNECTION_RESOURCE_ROOT')
 export const CONNECTION_RESOURCE_ROOT_LABEL = 'root' as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description of Changes

- What was changed?
  - Replaced the shared constant `FREE_AI_FILTERS_USAGE_MONTHLY_LIMIT` with `FREE_AI_FILTERS_USAGE_DAILY_LIMIT` and set it to `10`.
  - Updated backend AI filters usage tracking in `apps/api/orpc/routers/ai/filters.ts` to use daily Redis keys (`yyyy-MM-dd`) instead of monthly keys.
  - Updated backend reset logic to midnight next day (`startOfDay + 1 day`) and kept `resetAt` returned to clients aligned with the new daily window.
  - Updated desktop UI copy/accessibility text from "left this month" to "left today" and adjusted tooltip reset formatting to include time.
- Why was it changed?
  - To enforce a free AI filters cap of 10 per day rather than a monthly cap.
- Any related issues or discussions?
  - Requested directly in this task.

## Checklist

- [x] My changes are scoped and focused
- [x] I have tested the code locally

## Notes to reviewer

- Are there any specific things the reviewer should focus on?
  - Verify daily usage behavior around local midnight boundaries and UI reset timestamp display.
  - `pnpm -C apps/api run check-types` passes in this environment.
  - Full desktop `check-types` currently reports many pre-existing unrelated type errors; changed files lint clean with `pnpm exec eslint` on touched files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1d7dc66-6456-4011-b99b-c4ebf802e6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1d7dc66-6456-4011-b99b-c4ebf802e6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

